### PR TITLE
JS error "tinyMCE is not defined"

### DIFF
--- a/phpmyfaq/assets/js/phpmyfaq.js
+++ b/phpmyfaq/assets/js/phpmyfaq.js
@@ -2061,7 +2061,7 @@
 $(document).ready(function () {
     "use script";
     $(window).unload(function () {
-        if (tinyMCE.activeEditor !== null) {
+        if (typeof tinyMCE !== 'undefined' && tinyMCE.activeEditor !== null) {
             if (tinyMCE.activeEditor.isDirty()) {
                 var chk = confirm('Do you want to save the article before navigating away?');
 


### PR DESCRIPTION
On phpMyFAQ start page, I've been greeted by the JS error "tinyMCE is not defined". This simple check should fix this.
