### PR TITLE
Use unicode entities for IE9 and below

### DIFF
--- a/phpmyfaq/inc/PMF/Pagination.php
+++ b/phpmyfaq/inc/PMF/Pagination.php
@@ -105,14 +105,14 @@ class PMF_Pagination
      *
      * @var string
      */
-    protected $firstPageLinkTpl = '<li><a href="{LINK_URL}">&larrb;</a></li>';
+    protected $firstPageLinkTpl = '<li><a href="{LINK_URL}">&#8676;</a></li>';
     
     /**
      * Last page link template
      *
      * @var string
      */
-    protected $lastPageLinkTpl = '<li><a href="{LINK_URL}">&rarrb;</a></li>';
+    protected $lastPageLinkTpl = '<li><a href="{LINK_URL}">&#8677;</a></li>';
     
     /**
      * Layout template


### PR DESCRIPTION
This is a fix for #655. I replaced the "arrow to bar" entities as IE9 and below do not recognize them. Instead I'm using unicode entities now. This should not make a difference in Firefox and Chrome.
