### PR TITLE
Fix attempt for #653

### DIFF
--- a/phpmyfaq/assets/js/functions.js
+++ b/phpmyfaq/assets/js/functions.js
@@ -35,7 +35,6 @@ var toggleFieldset,
     refreshCaptcha,
     showLongComment,
     saveFormValues,
-    autoSuggest,
     saveVoting,
     checkQuestion;
 
@@ -305,7 +304,7 @@ $(document).ready(function () {
      *
      * @return void
      */
-    autoSuggest = function autoSuggest() {
+    var autoSuggest = function autoSuggest() {
         $('input#instantfield').keyup(function () {
             var search   = $('#instantfield').val(),
                 language = $('#ajaxlanguage').val(),
@@ -330,6 +329,8 @@ $(document).ready(function () {
             return false;
         });
     };
+
+    autoSuggest();
 
     /**
      * Saves the voting by Ajax

--- a/phpmyfaq/assets/js/phpmyfaq.js
+++ b/phpmyfaq/assets/js/phpmyfaq.js
@@ -2299,7 +2299,6 @@ var toggleFieldset,
     refreshCaptcha,
     showLongComment,
     saveFormValues,
-    autoSuggest,
     saveVoting,
     checkQuestion;
 
@@ -2569,7 +2568,7 @@ $(document).ready(function () {
      *
      * @return void
      */
-    autoSuggest = function autoSuggest() {
+    var autoSuggest = function autoSuggest() {
         $('input#instantfield').keyup(function () {
             var search   = $('#instantfield').val(),
                 language = $('#ajaxlanguage').val(),
@@ -2594,6 +2593,8 @@ $(document).ready(function () {
             return false;
         });
     };
+
+    autoSuggest();
 
     /**
      * Saves the voting by Ajax

--- a/phpmyfaq/assets/template/default/index.tpl
+++ b/phpmyfaq/assets/template/default/index.tpl
@@ -128,7 +128,7 @@
                 <form id="instantform" action="?action=instantresponse" method="post" class="form-search">
                     <input type="hidden" name="ajaxlanguage" id="ajaxlanguage" value="{ajaxlanguage}" />
                     <input type="search" name="search" id="instantfield" class="input-xxlarge search-query" value=""
-                           placeholder="{msgDescriptionInstantResponse}" onfocus="autoSuggest(); return false;" />
+                           placeholder="{msgDescriptionInstantResponse}" />
                 </form>
                 <small>{msgSearch}</small>
             </section>

--- a/phpmyfaq/assets/template/default/instantresponse.tpl
+++ b/phpmyfaq/assets/template/default/instantresponse.tpl
@@ -3,8 +3,7 @@
             <section class="well" id="searchBox">
                 <form id="instantform" action="?action=instantresponse" method="post" class="form-search">
                     <input id="instantfield" type="search" name="search" value="{searchString}"
-                           class="input-xxlarge search-query" placeholder="{msgDescriptionInstantResponse}"
-                           onfocus="autoSuggest()"/>
+                           class="input-xxlarge search-query" placeholder="{msgDescriptionInstantResponse}"/>
                     <input id="ajaxlanguage" name="ajaxlanguage" type="hidden" value="{ajaxlanguage}" />
                 </form>
             </section>


### PR DESCRIPTION
When investigating issue #653, I noticed that you register two event handlers everytime the focus event of the instant response input field fires. imho, this is unnecessary.

I changed this, so the registration is done globally on documentReady. The fun side effect of that is that the problem described in issue #653 was gone afterwards.
