### PR TITLE
Add support for MySQL sockets

### DIFF
--- a/phpmyfaq/inc/PMF/DB/Mysqli.php
+++ b/phpmyfaq/inc/PMF/DB/Mysqli.php
@@ -70,7 +70,13 @@ class PMF_DB_Mysqli implements PMF_DB_Driver
      */
     public function connect($host, $user, $password, $database = '')
     {
-        $this->conn = new mysqli($host, $user, $password);
+        if (substr($host, 0, 1)=='/') {
+                // Connect to MySQL via socket
+                $this->conn = new mysqli(null, $user, $password, null, null, $host);
+        } else {
+                // Connect to MySQL via network
+                $this->conn = new mysqli($host, $user, $password);
+        }
         if ($this->conn->connect_error) {
             PMF_Db::errorPage($this->conn->connect_errno . ': ' . $this->conn->connect_error);
             die();


### PR DESCRIPTION
On my server, connection to MySQL is via a UNIX socket - not via networking.

See the MySQL "skip-networking" configuration option: http://dev.mysql.com/doc/refman/5.6/en/server-options.html#option_mysqld_skip-networking

Currently the Mysqli.php driver only supports network connections.

It is conventional to interpret a host-name beginning with a "/" as a path to the socket file instead of a hostname.  e.g.  "/var/run/mysqld/mysqld.sock"
