### PR TITLE
PMF_ROOT_DIR was defined twice

### DIFF
--- a/phpmyfaq/inc/Bootstrap.php
+++ b/phpmyfaq/inc/Bootstrap.php
@@ -98,11 +98,6 @@ if (file_exists(__DIR__ . '/../multisite/multisite.php') && 'cli' !== PHP_SAPI) 
 }
 
 //
-// Set root dir
-//
-define('PMF_ROOT_DIR', dirname(__DIR__));
-
-//
 // Read configuration and constants
 //
 if (! defined('PMF_MULTI_INSTANCE_CONFIG_DIR')) {


### PR DESCRIPTION
The constant PMF_ROOT_DIR is already defined in line 45 of Bootstrap.php, so the redefinition in line 103 will throw a notice.
