### PR TITLE
Updated currentPageUrl to fix canonical name.

### DIFF
--- a/phpmyfaq/index.php
+++ b/phpmyfaq/index.php
@@ -473,7 +473,7 @@ $tplMainPage = array(
     'metaCharset'          => 'utf-8', // backwards compability
     'phpmyfaqversion'      => $faqConfig->get('main.currentVersion'),
     'stylesheet'           => $PMF_LANG['dir'] == 'rtl' ? 'style.rtl' : 'style',
-    'currentPageUrl'       => $currentPageUrl,
+    'currentPageUrl'       => preg_match( '/(\S+\/content\/\S+.html)\?\S*/', $currentPageUrl, $canonical ) === 1 ? $canonical[1] : $currentPageUrl,
     'action'               => $action,
     'dir'                  => $PMF_LANG['dir'],
     'headerCategories'     => $PMF_LANG['msgFullCategories'],


### PR DESCRIPTION
This change allows articles to keep their correct canonical name when using things like search text highlighting in the query string.
This will only work with URL rewriting, and only affects articles.

The purpose of this change is to prevent search engines from seeing duplicated content ( once people do a search, many links suddenly have the same data, but different canonical names ).

This problem affects certain other pages, however it seems important for articles to have the fix ( I'm not worried about the login page and others ). 

Also if other pages containing the extension .html do not have significant info in the query string ( compared to the non .html link: http://site.com/FAQ/?action=login ) then the regex can become a little simpler. `(\S+.html)\?(\S*)`
