### PR TITLE
Updated currentPageUrl to fix canonical name.

### DIFF
--- a/phpmyfaq/index.php
+++ b/phpmyfaq/index.php
@@ -476,7 +476,7 @@ $tplMainPage = array(
     'metaCharset'          => 'utf-8', // backwards compability
     'phpmyfaqversion'      => $faqConfig->get('main.currentVersion'),
     'stylesheet'           => $PMF_LANG['dir'] == 'rtl' ? 'style.rtl' : 'style',
-    'currentPageUrl'       => $currentPageUrl,
+    'currentPageUrl'       => preg_match( '/(\S+\/content\/\S+.html)\?\S*/', $currentPageUrl, $canonical ) === 1 ? $canonical[1] : $currentPageUrl,
     'action'               => $action,
     'dir'                  => $PMF_LANG['dir'],
     'msgCategory'          => $PMF_LANG['msgCategory'],


### PR DESCRIPTION
This change allows articles to keep their correct canonical name when using things like search text highlighting in the query string.
This will only work with URL rewriting, and only affects articles.

The purpose of this change is to prevent search engines from seeing duplicated content ( once people do a search, many links suddenly have the same data, but different canonical names ).

Moved from master branch: https://github.com/thorsten/phpMyFAQ/pull/912
