### PR TITLE
Updated glossary/highlight fix.

### DIFF
--- a/phpmyfaq/assets/template/default/artikel.tpl
+++ b/phpmyfaq/assets/template/default/artikel.tpl
@@ -183,7 +183,7 @@
             
             //This is a temporary fix and can be removed once a proper solution is found.
             //Removes unrendered glossary entries injected into source code.
-            $( 'pre' ).find( 'abbr' ).replaceWith( function (){ return $( this ).text(); } );
+            $( 'pre' ).find( 'abbr,mark' ).replaceWith( function (){ return $( this ).text(); } );
             
             SyntaxHighlighter.all();
             </script>


### PR DESCRIPTION
This change now allows the removal of highlighting `mark` tags from appearing inside code boxes.

Closes https://github.com/thorsten/phpMyFAQ/issues/384
