### PR TITLE
Modified default/failed return value.

### DIFF
--- a/phpmyfaq/api.php
+++ b/phpmyfaq/api.php
@@ -114,11 +114,9 @@ switch ($action) {
         $faq->getRecord($recordId);
         $result = $faq->faqRecord;
         break;
-
-    default:
-        $result = 'I am completely operational, and all my circuits are functioning perfectly.';
-        break;
 }
+
+if( empty( $result ) ) $result = array( 'result' => false );
 
 // print result as JSON
 echo json_encode($result);


### PR DESCRIPTION
I would like to implement a usable return value for failure. The string seems fine, however a value that would always produce a valid JSON object makes life easier on the receiving end.

For instance: a case that fails can fall through ( in api.php, and `break;` on success ), or a javascript client can rely on `if( json.result ){}`

This may of course require the current api options to not touch $result on failure, which is easily implemented.

If you are interested in the idea, or something similar, I will go and verify the current API to ensure failure is correctly handled, and add the commits here.
