### PR TITLE
Fixed 2 errors in the setup for postgresql database

### DIFF
--- a/phpmyfaq/setup/assets/sql/pgsql.sql.php
+++ b/phpmyfaq/setup/assets/sql/pgsql.sql.php
@@ -71,7 +71,7 @@ last_login varchar(14) NULL,
 auth_source varchar(100) NULL,
 member_since varchar(14) NULL,
 remember_me VARCHAR(150) NULL,
-success INT(1) NULL DEFAULT 1,
+success INTEGER NULL DEFAULT 1,
 PRIMARY KEY (user_id))";
 
 //faqgroup
@@ -241,7 +241,7 @@ PRIMARY KEY (group_id, right_id)
 
 //faqinstances
 $query[] = "CREATE TABLE " . $sqltblpre . "faqinstances (
-id int4 NOT NULL,
+id SERIAL NOT NULL,
 url VARCHAR(255) NOT NULL,
 instance VARCHAR(255) NOT NULL,
 comment TEXT NULL,


### PR DESCRIPTION
![schermafdruk van 2015-06-30 10-56-35](https://cloud.githubusercontent.com/assets/8068425/8427606/f1cae7ba-1f18-11e5-86d8-28e914e297f0.png)
![schermafdruk van 2015-06-30 10-59-11](https://cloud.githubusercontent.com/assets/8068425/8427607/f1cca8de-1f18-11e5-9ccf-f0ee64727a1d.png)

Bug 1
Int with precision does not work/exist for Postgres, I checked out what this does on https://dev.mysql.com/doc/refman/5.0/en/numeric-type-attributes.html and this seams to have something to do with the 'display width'. I don't know if this is of any use for the MySQL version of the setup script..

Bug 2
The table faqinstances is expected to have a faqinstances_id_seq sequence, so I guess this should be auto-numbering. I changed the field type from int to serial.