### PR TITLE
Corrects LDAP option bug by retrieving the constant value.

### DIFF
--- a/phpmyfaq/inc/PMF/Ldap.php
+++ b/phpmyfaq/inc/PMF/Ldap.php
@@ -118,7 +118,7 @@ class PMF_Ldap
         // optionally set Bind version
         if (isset($this->_ldapConfig['ldap_options'])) {
             foreach ($this->_ldapConfig['ldap_options'] as $key => $value) {
-                if (! ldap_set_option($this->ds, $key, $value)) {
+                if (! ldap_set_option($this->ds, constant($key), $value)) {
                     $this->errno = ldap_errno($this->ds);
                     $this->error = sprintf(
                         'Unable to set LDAP option "%s" to "%s" (Error: %s).',


### PR DESCRIPTION
ldap_set_option expects an integer value to be provided for the option.
This change properly looked up the integer value based on the name of
the constant being passed.