### PR TITLE
Replace loop with keys in $this->categories

### DIFF
--- a/phpmyfaq/inc/PMF/Category.php
+++ b/phpmyfaq/inc/PMF/Category.php
@@ -307,13 +307,11 @@ class PMF_Category
     {
         $tt = [];
         $x = 0;
-        $loop = 0;
 
-        foreach ($this->categories as $n) {
+        foreach ($this->categories as $k => $n) {
             if (isset($n['parent_id']) && $n['parent_id'] == $id_parent) {
-                $tt[$x++] = $loop;
+                $tt[$x++] = $k;
             }
-            $loop++;
         }
 
         if ($x != 0) {


### PR DESCRIPTION
Since method `getAllCategories` used `$category_id` as index, we had better use keys in `$this->categories`.