### PR TITLE
Removed duplicate entries. Allowed non-SSL GIT access.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,8 @@
         "phpunit/dbunit": "1.3.*"
     },
     "config": {
-        "bin-dir": "bin"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "4.0.*",
-        "phpunit/dbunit": "1.3.*"
-    },
-    "config": {
-        "bin-dir": "bin"
+        "bin-dir": "bin",
+        "secure-http": false
     },
     "minimum-stability": "stable",
     "scripts": {


### PR DESCRIPTION
Installing from GIT (as per README.md) with new Composer failed, because non-SSL GIT (over git:// and http://) is disabled by default in new Composer. See https://github.com/composer/composer/issues/5475.