### PR TITLE
Installing on a machine with SQLite as the only RDBMS

### DIFF
--- a/phpmyfaq/assets/js/setup.js
+++ b/phpmyfaq/assets/js/setup.js
@@ -52,5 +52,10 @@ $(document).ready(function() {
 
     setupForm.find('a').on('click', addInput);
     setupType.on('change', selectDatabaseSetup);
+    var setupTypeOptions= $('#sql_type option');
+    if( setupTypeOptions.length===1 ) {
+        $('#dbsqlite').show().removeClass('hide');
+        $('#dbdatafull').hide();
+    }
 
 });


### PR DESCRIPTION
Enabling SQLite-specific install fields, when installing on a machine that only supports SQLite (and therefore there are no other RDBMS listed).

For https://github.com/thorsten/phpMyFAQ/issues/1194