### PR TITLE
Removed column width from data type INT

### DIFF
--- a/phpmyfaq/setup/assets/sql/sqlsrv.sql.php
+++ b/phpmyfaq/setup/assets/sql/sqlsrv.sql.php
@@ -343,7 +343,7 @@ last_login varchar(14) NULL,
 auth_source varchar(100) NULL,
 member_since varchar(14) NULL,
 remember_me VARCHAR(150) NULL,
-success INT(1) NULL DEFAULT 1,
+success INT NULL DEFAULT 1,
 PRIMARY KEY (user_id))";
 
 //faquserdata


### PR DESCRIPTION
Fixed issue #1300 where "DB error: 42000: [Microsoft][ODBC Driver 13 for SQL Server][SQL Server]Column, parameter, or variable #11: Cannot specify a column width on data type int." received on setup