### PR TITLE
consider enableRegistration for registrations

### DIFF
--- a/phpmyfaq/login.php
+++ b/phpmyfaq/login.php
@@ -41,7 +41,7 @@ try {
 $tpl->parse(
     'writeContent',
     array(
-        'registerUser' => '<a href="?action=register">'.$PMF_LANG['msgRegistration'].'</a>',
+        'registerUser' => $faqConfig->get('security.enableRegistration') ? '<a href="?action=register">'.$PMF_LANG['msgRegistration'].'</a>' : '',
         'sendPassword' => '<a href="?action=password">'.$PMF_LANG['lostPassword'].'</a>',
         'loginHeader' => $PMF_LANG['msgLoginUser'],
         'loginMessage' => $loginMessage,

--- a/phpmyfaq/register.php
+++ b/phpmyfaq/register.php
@@ -24,6 +24,10 @@ if (!defined('IS_VALID_PHPMYFAQ')) {
     if (isset($_SERVER['HTTPS']) && strtoupper($_SERVER['HTTPS']) === 'ON') {
         $protocol = 'https';
     }
+    exit();
+}
+
+if (!$faqConfig->get('security.enableRegistration')) {
     header('Location: '.$protocol.'://'.$_SERVER['HTTP_HOST'].dirname($_SERVER['SCRIPT_NAME']));
     exit();
 }


### PR DESCRIPTION
Currently registration is possible even if security.enableRegistration is
disabled.
This commit disables the registration by redirecting to the index page
and also disables the registration link on the login form.

