### PR TITLE
Replace default value in url by placeholder

### DIFF
--- a/phpmyfaq/admin/news.php
+++ b/phpmyfaq/admin/news.php
@@ -111,7 +111,7 @@ if ('addnews' == $action && $user->perm->checkRight($user->getUserId(), 'addnews
                         <label class="col-lg-2 control-label" for="link"><?php echo $PMF_LANG['ad_news_link_url'];
     ?></label>
                         <div class="col-lg-4">
-                            <input class="form-control" type="url" name="link" id="link" value="http://">
+                            <input class="form-control" type="url" name="link" id="link" placeholder="http://www.example.com/">
                         </div>
                     </div>
 


### PR DESCRIPTION
Current browsers display a warning if no valid url is entered into an url field of a form.

On the "Add News" page this happens as well if create a news entry, but do not (want to) specify an url at all.

![browser warning url](https://user-images.githubusercontent.com/29982026/28119890-a9cf4c6a-6716-11e7-8294-e33063afca99.png)

You have to deleted the "http://" manually before it is possible to save the news entry.

This could be avoided by using the "placeholder" attribute instead of the "value" attribute.
![newversion](https://user-images.githubusercontent.com/29982026/28120059-3f8e04a8-6717-11e7-8e30-1f2fca2a0219.png)
This way, the desired format is shown, but the user is not forced to take any action if no url is desired.
