### PR TITLE
Add to the search API a filter by category

### DIFF
--- a/phpmyfaq/api.php
+++ b/phpmyfaq/api.php
@@ -81,8 +81,9 @@ switch ($action) {
         $faq             = new PMF_Faq($faqConfig);
         $user            = new PMF_User($faqConfig);
         $search          = new PMF_Search($faqConfig);
+        $search->setCategoryId($categoryId);
+        
         $faqSearchResult = new PMF_Search_Resultset($user, $faq, $faqConfig);
-
         $searchString  = PMF_Filter::filterInput(INPUT_GET, 'q', FILTER_SANITIZE_STRIPPED);
         $searchResults = $search->search($searchString, false);
         $url           = $faqConfig->get('main.referenceURL') . '/index.php?action=artikel&cat=%d&id=%d&artlang=%s';


### PR DESCRIPTION
Currently there's not a chance to filter the searched FAQs by category, it could be a nice filter to have, and more than nice a util filter in some cases