### PR TITLE
updated new files required for category/group restrictions in admin page.

### DIFF
--- a/phpmyfaq/admin/ajax.group.php
+++ b/phpmyfaq/admin/ajax.group.php
@@ -32,10 +32,17 @@ $groupId = PMF_Filter::filterInput(INPUT_GET, 'group_id', FILTER_VALIDATE_INT);
 
 if ($user->perm->checkRight($user->getUserId(), 'adduser') ||
     $user->perm->checkRight($user->getUserId(), 'edituser') ||
-    $user->perm->checkRight($user->getUserId(), 'deluser')) {
-    $user = new PMF_User($faqConfig);
-    $userList = $user->getAllUsers();
-    $groupList = ($user->perm instanceof PMF_Perm_Medium) ? $user->perm->getAllGroups() : [];
+    $user->perm->checkRight($user->getUserId(), 'deluser')) ||
+    $user->perm->checkRight($user->getUserId(), 'editgroup')) {
+    
+    // pass the user id of the current user so it'll check which group he belongs to
+    $groupList = ($user->perm instanceof PMF_Perm_Medium) ? $user->perm->getAllGroups($user->getUserId()) : [];
+
+    if ($faqConfig->config['main.enableCategoryRestrictions'] == false){
+        // orig code
+        $user = new PMF_User($faqConfig);
+        $groupList = ($user->perm instanceof PMF_Perm_Medium) ? $user->perm->getAllGroups() : [];
+    }
 
     // Returns all groups
     if ('get_all_groups' == $ajaxAction) {

--- a/phpmyfaq/admin/category.add.php
+++ b/phpmyfaq/admin/category.add.php
@@ -37,6 +37,14 @@ if (!defined('IS_VALID_PHPMYFAQ')) {
         <div class="row">
             <div class="col-lg-12">
 <?php
+$currentUserId = 1;
+
+if ( $faqConfig->config['main.enableCategoryRestrictions'] == 'true' && $user->getUserId() != 1){
+
+    $currentUserId = $user->getUserId();
+}
+
+
 if ($user->perm->checkRight($user->getUserId(), 'addcateg')) {
     $category = new PMF_Category($faqConfig, [], false);
     $category->setUser($currentAdminUser);
@@ -130,7 +138,7 @@ if ($user->perm->checkRight($user->getUserId(), 'addcateg')) {
                         <label class="col-lg-2 control-label" for="group_id"><?php echo $PMF_LANG['ad_categ_moderator'] ?>:</label>
                         <div class="col-lg-4">
                             <select name="group_id" id="group_id" size="1" class="form-control">
-                                <?php echo $user->perm->getAllGroupsOptions([]) ?>
+                                <?php echo $user->perm->getAllGroupsOptions([],$currentUserId) ?>
                             </select>
                         </div>
                     </div>

--- a/phpmyfaq/admin/category.edit.php
+++ b/phpmyfaq/admin/category.edit.php
@@ -24,6 +24,11 @@ if (!defined('IS_VALID_PHPMYFAQ')) {
     exit();
 }
 
+$currentUserId = 1;
+if ( $faqConfig->config['main.enableCategoryRestrictions'] == 'true' && $user->getUserId() != 1){
+    $currentUserId = $user->getUserId();
+}
+
 if ($user->perm->checkRight($user->getUserId(), 'editcateg')) {
     $categoryId = PMF_Filter::filterInput(INPUT_GET, 'cat', FILTER_VALIDATE_INT, 0);
 
@@ -145,7 +150,7 @@ if ($user->perm->checkRight($user->getUserId(), 'editcateg')) {
                 <label class="col-lg-2 control-label" for="group_id"><?php echo $PMF_LANG['ad_categ_moderator'] ?>:</label>
                 <div class="col-lg-4">
                     <select name="group_id" id="group_id" size="1" class="form-control">
-                        <?php echo $user->perm->getAllGroupsOptions([$categoryData->getGroupId()]) ?>
+                        <?php echo $user->perm->getAllGroupsOptions([$categoryData->getGroupId()],$currentUserId) ?>
                     </select>
                 </div>
             </div>
@@ -166,7 +171,7 @@ if ($user->perm->checkRight($user->getUserId(), 'editcateg')) {
                         <?php echo $PMF_LANG['ad_entry_restricted_groups'] ?>
                     </label>
                     <select name="restricted_groups[]" size="3" class="form-control" multiple>
-                        <?php echo $user->perm->getAllGroupsOptions($groupPermission) ?>
+                        <?php echo $user->perm->getAllGroupsOptions([$categoryData->getGroupId()],$currentUserId) ?>
                     </select>
                 </div>
             </div>

--- a/phpmyfaq/admin/category.main.php
+++ b/phpmyfaq/admin/category.main.php
@@ -285,7 +285,17 @@ if ($user->perm->checkRight($user->getUserId(), 'editcateg') && $csrfCheck) {
     if (isset($category)) {
         unset($category);
     }
+    // old code
     $category = new PMF_Category($faqConfig, [], false);
+    //
+
+    // new code
+    if ($faqConfig->config['main.enableCategoryRestrictions'] == 'true' && $user->getUserId() != 1){
+        
+        $category = new PMF_Category($faqConfig, $currentAdminGroups, true);
+    }
+    //
+    
     $category->setUser($currentAdminUser);
     $category->setGroups($currentAdminGroups);
     $category->getMissingCategories();

--- a/phpmyfaq/admin/record.edit.php
+++ b/phpmyfaq/admin/record.edit.php
@@ -26,9 +26,21 @@ if (!defined('IS_VALID_PHPMYFAQ')) {
     exit();
 }
 
+$currentUserId = 1;
+
 if (($user->perm->checkRight($user->getUserId(), 'editbt') ||
     $user->perm->checkRight($user->getUserId(), 'addbt')) && !PMF_Db::checkOnEmptyTable('faqcategories')) {
+    // old code
     $category = new PMF_Category($faqConfig, [], false);
+    //
+
+    // new code
+    if ( $faqConfig->config['main.enableCategoryRestrictions'] == 'true' && $user->getUserId() != 1){
+        $currentUserId = $user->getUserId();
+        $category = new PMF_Category($faqConfig, $currentAdminGroups, true);
+    }
+    //
+    
     $category->setUser($currentAdminUser);
     $category->setGroups($currentAdminGroups);
     $category->buildTree();
@@ -723,7 +735,7 @@ if (($user->perm->checkRight($user->getUserId(), 'editbt') ||
                                         <?php echo($restrictedGroups ? 'checked' : ''); ?>>
                                     <?php echo $PMF_LANG['ad_entry_restricted_groups'] ?>
                                     <select name="restricted_groups[]" size="3" class="form-control" multiple>
-                                        <?php echo $user->perm->getAllGroupsOptions($groupPermission) ?>
+                                        <?php echo $user->perm->getAllGroupsOptions($groupPermission,$currentUserId) ?>
                                     </select>
                                 </label>
                             </div>

--- a/phpmyfaq/admin/record.show.php
+++ b/phpmyfaq/admin/record.show.php
@@ -133,6 +133,8 @@ if ($user->perm->checkRight($user->getUserId(), 'editbt') || $user->perm->checkR
 
     $comment = new PMF_Comment($faqConfig);
     $faq = new PMF_Faq($faqConfig);
+    $faq->setUser($currentAdminUser);
+    $faq->setGroups($currentAdminGroups);
     $date = new PMF_Date($faqConfig);
 
     $internalSearch = '';
@@ -174,7 +176,7 @@ if ($user->perm->checkRight($user->getUserId(), 'editbt') || $user->perm->checkR
         <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
 <?php
     $numCommentsByFaq = $comment->getNumberOfComments();
-    $numRecordsByCat = $category->getNumberOfRecordsOfCategory();
+    $numRecordsByCat = $category->getNumberOfRecordsOfCategory($faqConfig->config['main.enableCategoryRestrictions'],$user->getUserId());
 
     $matrix = $category->getCategoryRecordsMatrix();
     foreach ($matrix as $catkey => $value) {
@@ -187,7 +189,16 @@ if ($user->perm->checkRight($user->getUserId(), 'editbt') || $user->perm->checkR
     }
 
     if (is_null($searchTerm)) {
-        $faq->getAllRecords($orderBy, null, $sortBy);
+        // new code 10-02-17 added language in params.
+        if ( $faqConfig->config['main.enableCategoryRestrictions'] == 'true' && $user->getUserId() != 1){
+            $Language = new PMF_Language($faqConfig);
+            $language = $Language->setLanguage($faqConfig->get('main.languageDetection'), $faqConfig->get('main.language'));
+            $faq->getAllRecords($orderBy, ['lang' => $language], $sortBy);  
+        }else{
+            $faq->getAllRecords($orderBy, null, $sortBy);
+        }
+        //
+        
         foreach ($faq->faqRecords as $record) {
             if (!isset($numActiveByCat[$record['category_id']])) {
                 $numActiveByCat[$record['category_id']] = 0;

--- a/phpmyfaq/lang/language_en.php
+++ b/phpmyfaq/lang/language_en.php
@@ -565,6 +565,7 @@ $LANG_CONF['records.maxAttachmentSize'] = array(0 => "input", 1 => "Maximum size
 $LANG_CONF["records.disableAttachments"] = array(0 => "checkbox", 1 => "Enable visibilty of attachments");
 $LANG_CONF["main.enableUserTracking"] = array(0 => "checkbox", 1 => "Enable user tracking");
 $LANG_CONF["main.enableAdminLog"] = array(0 => "checkbox", 1 => "use Adminlog?");
+$LANG_CONF["main.enableCategoryRestrictions"] = array(0 => "checkbox", 1 => "Enable category restrictions");
 $LANG_CONF["security.ipCheck"] = array(0 => "checkbox", 1 => "Check the IP in administration");
 $LANG_CONF["records.numberOfRecordsPerPage"] = array(0 => "input", 1 => "Number of displayed topics per page");
 $LANG_CONF["records.numberOfShownNewsEntries"] = array(0 => "input", 1 => "Number of news articles");

--- a/phpmyfaq/src/PMF/Category.php
+++ b/phpmyfaq/src/PMF/Category.php
@@ -1775,24 +1775,47 @@ class PMF_Category
      *
      * @return array
      */
-    public function getNumberOfRecordsOfCategory()
+    public function getNumberOfRecordsOfCategory($categoryRestriction = false, $userId = 1)
     {
         $numRecordsByCat = [];
 
-        $query = sprintf('
-            SELECT
-                fcr.category_id AS category_id,
-                COUNT(fcr.record_id) AS number
-            FROM
-                %sfaqcategoryrelations fcr, %sfaqdata fd
-            WHERE
-                fcr.record_id = fd.id
-            AND
-                fcr.record_lang = fd.lang
-            GROUP BY fcr.category_id',
-            PMF_Db::getTablePrefix(),
-            PMF_Db::getTablePrefix());
-
+        if ( $categoryRestriction == 'true' && $userId != 1){
+            // when category restriction is enabled.
+            $query = sprintf('
+                SELECT
+                    fcr.category_id AS category_id,
+                    COUNT(fcr.record_id) AS number
+                FROM
+                    %sfaqcategoryrelations fcr
+                LEFT JOIN
+                    %sfaqdata fd on fcr.record_id = fd.id
+                LEFT JOIN
+                    %sfaqdata_group fdg on fdg.record_id = fcr.record_id
+                WHERE
+                    fdg.group_id = %s
+                AND
+                    fcr.record_lang = fd.lang
+                GROUP BY fcr.category_id',
+                PMF_Db::getTablePrefix(),
+                PMF_Db::getTablePrefix(),
+                PMF_Db::getTablePrefix(),
+                $this->groups[1]);
+        }else{
+            // orignal query
+            $query = sprintf('
+                SELECT
+                    fcr.category_id AS category_id,
+                    COUNT(fcr.record_id) AS number
+                FROM
+                    %sfaqcategoryrelations fcr, %sfaqdata fd
+                WHERE
+                    fcr.record_id = fd.id
+                AND
+                    fcr.record_lang = fd.lang
+                GROUP BY fcr.category_id',
+                PMF_Db::getTablePrefix(),
+                PMF_Db::getTablePrefix());
+        }
         $result = $this->_config->getDb()->query($query);
 
         if ($this->_config->getDb()->numRows($result) > 0) {

--- a/phpmyfaq/src/PMF/Faq.php
+++ b/phpmyfaq/src/PMF/Faq.php
@@ -1484,6 +1484,8 @@ class PMF_Faq
                 break;
         }
 
+        // prevents multiple display of FAQ incase it is tagged under multiple groups.
+        $group_by = ' group by fd.id, fcr.category_id,fd.solution_id,fd.revision_id,fd.active,fd.sticky,fd.keywords,fd.thema,fd.content,fd.author,fd.email,fd.comment,fd.updated,fd.links_state,fd.links_check_date,fd.date_start,fd.date_end,fd.sticky,fd.created,fd.notes,fd.lang ';
         $query = sprintf('
             SELECT
                 fd.id AS id,
@@ -1525,6 +1527,7 @@ class PMF_Faq
                 fd.id = fdu.record_id
             %s
             %s
+            %s
             %s',
             PMF_Db::getTablePrefix(),
             PMF_Db::getTablePrefix(),
@@ -1532,6 +1535,7 @@ class PMF_Faq
             PMF_Db::getTablePrefix(),
             $where,
             $this->queryPermission($this->groupSupport),
+            $group_by,
             $orderBy
         );
 

--- a/phpmyfaq/src/PMF/Perm/Medium.php
+++ b/phpmyfaq/src/PMF/Perm/Medium.php
@@ -648,11 +648,11 @@ class PMF_Perm_Medium extends PMF_Perm_Basic
 
     /**
      * Returns an array with the IDs of all groups stored in the
-     * database.
-     *
+     * database if no user ID is passed.
+     * @param int userId 
      * @return array
      */
-    public function getAllGroups()
+    public function getAllGroups($userId = 1)
     {
         $select = sprintf('
             SELECT
@@ -661,6 +661,21 @@ class PMF_Perm_Medium extends PMF_Perm_Basic
                 %sfaqgroup',
             PMF_Db::getTablePrefix()
         );
+        if ($userId != 1){
+            $select = sprintf('
+                SELECT
+                    fg.group_id
+                FROM
+                    %sfaqgroup fg
+                LEFT JOIN
+                    %sfaquser_group fug ON fg.group_id=fug.group_id
+                WHERE
+                    fug.user_id = %d',
+                PMF_Db::getTablePrefix(),
+                PMF_Db::getTablePrefix(),
+                $userId
+            );
+        }
 
         $res = $this->config->getDb()->query($select);
         $result = [];
@@ -678,10 +693,10 @@ class PMF_Perm_Medium extends PMF_Perm_Basic
      *
      * @return string
      */
-    public function getAllGroupsOptions(Array $groups)
+    public function getAllGroupsOptions(Array $groups, $userID = 1)
     {
         $options = '';
-        $allGroups = $this->getAllGroups();
+        $allGroups = $this->getAllGroups($userID);
 
         foreach ($allGroups as $groupId) {
             if (-1 != $groupId) {


### PR DESCRIPTION
Hi Thorsten,

Kindly also run this query on your psql.
insert into faqconfig (config_name ,config_value) values ('main.enable_category_restrictions',true);

**Why do you set userID to 1?**
This is just to keep the  old view wherein when you're given an admin access, you'll be able to view other categories/group even if you're not tagged under it.

**Why the check for user ID 1?**
User ID 1 is for the super admin. Right now, everyone who has access to the admin page are considered as admin, if we'll have this category restriction feature, we need to have a super admin that sets permission on each admin, either which category they should handle or which group they should be on.

Kindly let me know if you need anything. Thanks.