### PR TITLE
Incorrect permission on New Question

### DIFF
--- a/phpmyfaq/ajaxservice.php
+++ b/phpmyfaq/ajaxservice.php
@@ -451,7 +451,7 @@ switch ($action) {
     case 'savequestion':
 
         if (!$faqConfig->get('records.allowQuestionsForGuests') &&
-            $user->perm->checkRight($user->getUserId(), 'addquestion')) {
+            !$user->perm->checkRight($user->getUserId(), 'addquestion')) {
             $message = array('error' => $PMF_LANG['err_NotAuth']);
             break;
         }


### PR DESCRIPTION
Similar fix to #1276 but for addquestion instead of addcomment

Patch made on 2.9 but probably applies to 2.10 too