### PR TITLE
Hide "Translate this FAQ" if there is only 1 language

### DIFF
--- a/phpmyfaq/artikel.php
+++ b/phpmyfaq/artikel.php
@@ -211,7 +211,8 @@ if (!empty($availableLanguages) && count($availableLanguages) > 1) {
     );
 }
 
-if ($user->perm->checkRight($user->getUserId(), 'addtranslation')) {
+if ($user->perm->checkRight($user->getUserId(), 'addtranslation') &&
+    !empty($availableLanguages) && count($availableLanguages) > 1) {
     $tpl->parseBlock(
         'writeContent',
         'addTranslation',


### PR DESCRIPTION
If you remove all of the languages bar 1, the "Translate this FAQ" is still shown and attempts to allow the user to do a translation anyway.

Prevent this from happening by hiding the "Translate this FAQ" serverside