### PR TITLE
Tighter permission control on the UI

### DIFF
--- a/phpmyfaq/add.php
+++ b/phpmyfaq/add.php
@@ -66,20 +66,32 @@ $categoryHelper->setCategory($category);
 
 $captchaHelper = new PMF_Helper_Captcha($faqConfig);
 
-// Enable/Disable WYSIWYG editor
-if ($faqConfig->get('main.enableWysiwygEditorFrontend')) {
+
+if(!$faqConfig->get('records.allowNewFaqsForGuests') &&
+   !$user->perm->checkRight($user->getUserId(), 'addfaq')) {
+    $tpl->parseBlock(
+        'writeContent',
+        'DisallowNewFaq',
+        [
+            'msgErrNotAuth' => $PMF_LANG['err_NotAuth'],
+        ]
+    );
+} else {
+    // Enable/Disable WYSIWYG editor
+    if ($faqConfig->get('main.enableWysiwygEditorFrontend')) {
     $tpl->parseBlock(
         'writeContent',
         'enableWysiwygEditor',
-        array(
+            [
             'currentTimestamp' => $_SERVER['REQUEST_TIME'],
-        )
+            ]
     );
-}
+    }
 
-$tpl->parse(
+    $tpl->parseBlock(
     'writeContent',
-    array(
+        'AllowNewFaq',
+        [
         'msgNewContentHeader' => $PMF_LANG['msgNewContentHeader'],
         'msgNewContentAddon' => $PMF_LANG['msgNewContentAddon'],
         'lang' => $Language->getLanguage(),
@@ -98,7 +110,13 @@ $tpl->parse(
         'msgNewContentLink' => $PMF_LANG['msgNewContentLink'],
         'captchaFieldset' => $captchaHelper->renderCaptcha($captcha, 'add', $PMF_LANG['msgCaptcha'], $auth),
         'msgNewContentSubmit' => $PMF_LANG['msgNewContentSubmit'],
-    )
+        ]
+    );
+}
+
+$tpl->parse(
+    'writeContent',
+    []
 );
 
 $tpl->parseBlock(

--- a/phpmyfaq/ask.php
+++ b/phpmyfaq/ask.php
@@ -55,8 +55,19 @@ $categoryHelper->setCategory($category);
 
 $captchaHelper = new PMF_Helper_Captcha($faqConfig);
 
-$tpl->parse(
+if(!$faqConfig->get('records.allowNewFaqsForGuests') &&
+   !$user->perm->checkRight($user->getUserId(), 'addquestion')) {
+    $tpl->parseBlock(
     'writeContent',
+        'DisallowAsk',
+        [
+            'msgErrNotAuth' => $PMF_LANG['err_NotAuth'],
+        ]
+    );
+} else {
+    $tpl->parseBlock(
+        'writeContent',
+        'AllowAsk',
     [
         'msgQuestion' => $PMF_LANG['msgQuestion'],
         'msgNewQuestion' => $PMF_LANG['msgNewQuestion'],
@@ -73,6 +84,12 @@ $tpl->parse(
         'captchaFieldset' => $captchaHelper->renderCaptcha($captcha, 'ask', $PMF_LANG['msgCaptcha'], $auth),
         'msgNewContentSubmit' => $PMF_LANG['msgNewContentSubmit'],
     ]
+    );
+}
+
+$tpl->parse(
+    'writeContent',
+    []
 );
 
 $tpl->parseBlock(

--- a/phpmyfaq/assets/js/comments.js
+++ b/phpmyfaq/assets/js/comments.js
@@ -39,6 +39,11 @@ $(function () {
         document.getElementById('pmf-create-comment').scrollIntoView();
     });
 
+    $('.show-comments').on('click', function(event) {
+        event.preventDefault();
+        document.getElementById('pmf-comments').scrollIntoView();
+    });
+
     $('.pmf-comments-show-more').on('click', function (event) {
         var commentId = $(this).data('comment-id');
         event.preventDefault();

--- a/phpmyfaq/assets/template/default/add.tpl
+++ b/phpmyfaq/assets/template/default/add.tpl
@@ -1,3 +1,12 @@
+[DisallowNewFaq]
+<section>
+            <p class="alert alert-danger">
+                {msgErrNotAuth}
+            </p>
+        </section>
+[/DisallowNewFaq]
+
+[AllowNewFaq]
 <section>
             <p>{msgNewContentAddon}</p>
             <form id="formValues" action="#" method="post" class="form-horizontal" accept-charset="utf-8">
@@ -71,7 +80,21 @@
 
         </section>
 
-        [enableWysiwygEditor]
+        <script>
+            $(document).ready(function() {
+                $('#submitfaq').click(function() {
+                    if (typeof tinyMCE !== 'undefined' && undefined !== tinyMCE) {
+                        tinyMCE.get('answer').setContent(tinyMCE.activeEditor.getContent());
+                        document.getElementById('answer').value = tinyMCE.activeEditor.getContent();
+                    }
+                    saveFormValues('savefaq', 'faq');
+                });
+                $('form#formValues').submit(function() { return false; });
+            });
+        </script>
+[/AllowNewFaq]
+
+[enableWysiwygEditor]
         <script src="admin/assets/js/editor/tinymce.min.js?{currentTimestamp}"></script>
         <script>
             $(document).ready(function() {
@@ -135,18 +158,5 @@
                 }
             });
         </script>
-        [/enableWysiwygEditor]
-
-        <script>
-            $(document).ready(function() {
-                $('#submitfaq').click(function() {
-                    if (typeof tinyMCE !== 'undefined' && undefined !== tinyMCE) {
-                        tinyMCE.get('answer').setContent(tinyMCE.activeEditor.getContent());
-                        document.getElementById('answer').value = tinyMCE.activeEditor.getContent();
-                    }
-                    saveFormValues('savefaq', 'faq');
-                });
-                $('form#formValues').submit(function() { return false; });
-            });
-        </script>
+[/enableWysiwygEditor]
 

--- a/phpmyfaq/assets/template/default/artikel.tpl
+++ b/phpmyfaq/assets/template/default/artikel.tpl
@@ -120,6 +120,7 @@
 
             <p class="hidden-print">{writeCommentMsg}</p>
 
+[AllowComments]
             <aside class="pmf-create-comment hide" id="pmf-create-comment">
 
                 <hr>
@@ -156,6 +157,7 @@
                     </div>
                 </form>
             </aside>
+[/AllowComments]
 
             <aside class="pmf-comments" id="comments">
                 <hr>

--- a/phpmyfaq/assets/template/default/ask.tpl
+++ b/phpmyfaq/assets/template/default/ask.tpl
@@ -1,3 +1,12 @@
+[DisallowAsk]
+<section>
+            <p class="alert alert-danger">
+                {msgErrNotAuth}
+            </p>
+        </section>
+[/DisallowAsk]
+
+[AllowAsk]
 <section>
 
             <div id="questionForm">
@@ -72,3 +81,4 @@
                 });
             });
         </script>
+[/AllowAsk]

--- a/phpmyfaq/inc/PMF/Faq.php
+++ b/phpmyfaq/inc/PMF/Faq.php
@@ -3013,7 +3013,7 @@ class PMF_Faq
      *
      * @return string
      */
-    public function printOpenQuestions()
+    public function printOpenQuestions($user)
     {
         global $sids, $category;
 
@@ -3086,6 +3086,12 @@ class PMF_Faq
                         $row->category_id,
                         $row->answer_id,
                         $this->pmf_lang['msg2answerFAQ']
+                    );
+                } else if(!$this->_config->get('records.allowNewFaqsForGuests') &&
+                          !$user->perm->checkRight($user->getUserId(), 'addfaq')) {
+                    $output .= sprintf(
+                        '<td>%s</td>',
+                        $this->pmf_lang['msg2unanswerFAQ']
                     );
                 } else {
                     $output .= sprintf(

--- a/phpmyfaq/index.php
+++ b/phpmyfaq/index.php
@@ -605,6 +605,20 @@ $tplNavigation['activeOpenQuestions'] = ('open' == $action) ? 'active' : '';
 $tplNavigation['activeLogin'] = ('login' == $action) ? 'active' : '';
 
 //
+// Hide "Add new FAQ" and "Add Question" from navigation if user does not have permission
+//
+if(!$faqConfig->get('records.allowNewFaqsForGuests') &&
+   !$user->perm->checkRight($user->getUserId(), 'addfaq'))
+{
+    $tplNavigation['msgAddContent'] = '';
+}
+if(!$faqConfig->get('records.allowQuestionsForGuests') &&
+   !$user->perm->checkRight($user->getUserId(), 'addquestion'))
+{
+    $tplNavigation['msgQuestion'] = '';
+}
+
+//
 // Show login box or logged-in user information
 //
 if (isset($auth)) {

--- a/phpmyfaq/lang/language_en.php
+++ b/phpmyfaq/lang/language_en.php
@@ -1124,6 +1124,7 @@ $PMF_LANG['ad_menu_searchfaqs'] = 'Search for FAQs';
 $LANG_CONF["records.enableCloseQuestion"] = array(0 => "checkbox", 1 => "Close open question after answer?");
 $LANG_CONF["records.enableDeleteQuestion"] = array(0 => "checkbox", 1 => "Delete open question after answer?");
 $PMF_LANG["msg2answerFAQ"] = "Answered";
+$PMF_LANG["msg2unanswerFAQ"] = "Unanswered";
 
 // added v2.8.0-alpha - 2012-01-16 by Thorsten
 $PMF_LANG["headerUserControlPanel"] = 'User Control Panel';

--- a/phpmyfaq/open.php
+++ b/phpmyfaq/open.php
@@ -44,7 +44,7 @@ $tpl->parse(
         'msgQuestionText' => $PMF_LANG['msgQuestionText'],
         'msgDate_User' => $PMF_LANG['msgDate_User'],
         'msgQuestion2' => $PMF_LANG['msgQuestion2'],
-        'printOpenQuestions' => $faq->printOpenQuestions()
+        'printOpenQuestions' => $faq->printOpenQuestions($user)
     ]
 );
 


### PR DESCRIPTION
Prevent users/guests from accessing the "Ask Question" and "Add New FAQ" pages
(also removing the navigation links) and also prevent them from adding comments
unless they have permission to do so or guest modifications are allowed.