### PR TITLE
Added "View FAQ" Button

### DIFF
--- a/phpmyfaq/admin/record.edit.php
+++ b/phpmyfaq/admin/record.edit.php
@@ -200,11 +200,14 @@ if (($user->perm->checkRight($user->getUserId(), 'editbt') ||
             $selectedRevisionId
         );
         printf(
-            '<i aria-hidden="true" class="fa fa-pencil"></i> %s <span class="text-error">%s</span> %s %s',
+			'<i aria-hidden="true" class="fa fa-pencil"></i> %s <span class="text-error">%s</span> %s %s <a href="/index.php?action=artikel&id=%s&artlang=%s" class="btn btn-info">%s</a>',
             $PMF_LANG['ad_entry_edit_1'],
             (0 === $faqData['id'] ? '' : $faqData['id']),
             $PMF_LANG['ad_entry_edit_2'],
-            $currentRevision
+            $currentRevision,
+			$faqData['id'],
+			$faqData['lang'],
+			$PMF_LANG['ad_view_faq']
         );
     } else {
         printf('<i aria-hidden="true" class="fa fa-pencil"></i> %s', $PMF_LANG['ad_entry_add']);

--- a/phpmyfaq/lang/language_en.php
+++ b/phpmyfaq/lang/language_en.php
@@ -1268,3 +1268,6 @@ $LANG_CONF['ldap.ldap_dynamic_login_attribute'] = array(0 => 'input', 1 => 'LDAP
 $LANG_CONF['seo.enableXMLSitemap'] = array('checkbox', 'Enable XML sitemap<br>(default: activated)');
 $PMF_LANG['ad_category_image'] = 'Category image';
 $PMF_LANG["ad_user_show_home"] = "Show on startpage";
+
+// added v.2.10.0-alpha - 2017-11-9 by Brian Potter (BrianPotter)
+$PMF_LANG['ad_view_faq'] = 'View FAQ';


### PR DESCRIPTION
Users in my organization requested a way to view a FAQ after editing it without having to navigate through the website. I added a "View FAQ" button after the revision number in the Edit view.