### PR TITLE
 Fix missing node.js dependency - Merge/check first

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "jquery-sparkline": "^2.3.2",
     "mermaid": "^7.1.0",
     "popper.js": "^1.12.6",
+    "sigmund": "^1.0.1",
     "tinymce": "^4.7.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This patch fixes a missing node.js dependency issue (possibly inherited from grunt-modernizr->customizr->modernizr tree - may be an upstream issue)

Regardless, allows travis-cl checks to clear successfully