### PR TITLE
FIX: $lockoutTime should be used only once

### DIFF
--- a/phpmyfaq/inc/PMF/User/CurrentUser.php
+++ b/phpmyfaq/inc/PMF/User/CurrentUser.php
@@ -624,7 +624,7 @@ class PMF_User_CurrentUser extends PMF_User
     }
 
     /**
-     * Sets IP and session timestamp plus lockout time, success flag to
+     * Sets IP and session timestamp, success flag to
      * false.
      *
      * @return mixed
@@ -641,7 +641,7 @@ class PMF_User_CurrentUser extends PMF_User
             WHERE
                 user_id = %d",
             PMF_Db::getTablePrefix(),
-            $_SERVER['REQUEST_TIME'] + $this->lockoutTime,
+            $_SERVER['REQUEST_TIME'],
             $_SERVER['REMOTE_ADDR'],
             $this->getUserId()
         );


### PR DESCRIPTION
The $logoutTime should not be used in the calculation of the session timestamp and in the check of the last login, but only in the login check function isFailedLastLoginAttempt (). 

Reasons:
1. It is more intuitive if the session timestamp represents the time of the actual login attempt.
2. If it is taken into account in both functions, the time has to elapse twice. This is not obvious to see.
