### PR TITLE
Filter result on all of the permissions

### DIFF
--- a/phpmyfaq/inc/PMF/Search/Resultset.php
+++ b/phpmyfaq/inc/PMF/Search/Resultset.php
@@ -122,9 +122,13 @@ class PMF_Search_Resultset
             $permission = false;
             // check permissions for groups
             if ('medium' === $this->_config->get('security.permLevel')) {
-                $groupPermission = $this->faq->getPermission('group', $result->id);
-                if (count($groupPermission) && in_array($groupPermission[0], $currentGroupIds)) {
-                    $permission = true;
+                $groupPermissions = $this->faq->getPermission('group', $result->id);
+                if (is_array($groupPermissions)) {
+                    foreach($groupPermissions as $permission) {
+                        if (in_array($permission, $currentGroupIds)) {
+                            $permission = true;
+                        }
+                    }
                 }
             }
             // check permission for user


### PR DESCRIPTION
When articles are asigned to specific permissions and you specify multiple groups it only uses the first group in the $groupPermission array which is -1.  This results in users not being able to find articles using the search engine.

Looping through this array and finding a match resulting in $permission = true; fixes the problem.