### PR TITLE
Return back to the original user state after rendering revisions for FAQ

### DIFF
--- a/phpmyfaq/admin/record.edit.php
+++ b/phpmyfaq/admin/record.edit.php
@@ -546,6 +546,7 @@ if (($user->perm->checkRight($user->getUserId(), 'editbt') ||
                         <div id="collapseViewChangelog" class="panel-collapse collapse">
                             <div class="panel-body">
                                 <?php
+								$currentUserId = $user->getUserId();
                                 foreach ($faq->getChangeEntries($faqData['id']) as $entry) {
                                     $user->getUserById($entry['user']);
                                     ?>
@@ -563,7 +564,10 @@ if (($user->perm->checkRight($user->getUserId(), 'editbt') ||
                                         </label>
                                         <?php echo $entry['changelog'] ?>
                                     </p>
-                                <?php } ?>
+                                <?php 
+								} 
+								$user->getUserById($currentUserId);
+								?>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Hello,

We've recently discovered a bug that we needed to be fixed asap, hence we already wrote the fix and would like to merge it into phpMyFAQ.

We have multiple users managing questions, and we noticed that for one account which had the right to update the visibility of a question, namely: "approverec" who could not set the visibility to visible.

Apparently checkRight failed which in turn showed me that the userId was different. I then discovered that the $user state changes when it is pulling the revision history. The last user in the foreach loop is the user that will be used from there on out. Which in turn resulted in the wrong userId being used for checkRight.

My fix is remembering the userId before entering the loop and setting the user back afterwards.
