### PR TITLE
query permissions for articles within a category

### DIFF
--- a/phpmyfaq/inc/PMF/Faq.php
+++ b/phpmyfaq/inc/PMF/Faq.php
@@ -2962,6 +2962,7 @@ class PMF_Faq
                 fcr.category_id = %d
             AND
                 fd.lang = '%s'
+                %s
             GROUP BY
                 fd.id, fd.lang, fd.thema, fcr.category_id, fv.visits
             ORDER BY
@@ -2975,6 +2976,7 @@ class PMF_Faq
             $now,
             $category,
             $this->_config->getLanguage()->getLanguage(),
+            $this->queryPermission($this->groupSupport),
             $this->_config->get('records.orderby'),
             $this->_config->get('records.sortby')
         );


### PR DESCRIPTION
In our production we noticed that articles within a certain category were shown on the right side when browsing an article regardless of whether the user had permission for it it or not.

Upon further inspection I noticed that the query being used did not make use of queryPermission. This pull request fixes that and the related articles on the right now shows only the articles users are allowed to see.

Whether this was intended or not, I don't know. Feel free to decline the pull request if this is the case.