### PR TITLE
fixed jquery member view in group management

### DIFF
--- a/phpmyfaq/admin/assets/js/groups.js
+++ b/phpmyfaq/admin/assets/js/groups.js
@@ -137,7 +137,7 @@ $(document).ready(function () {
 
                 members.each(function(member) {
 
-                    if (user.val() === member) {
+                    if (user.val() === members[member].value) {
                         isMember = true;
                     } else {
                         isMember = false;


### PR DESCRIPTION
It was possible to add a user multiple times to one group. (only in view)
Also in 3.0 the same bug. I already fixed it in my other pull request.

![grafik](https://user-images.githubusercontent.com/12272179/45959816-0d06ce80-c01b-11e8-86cf-29f64286bd63.png)

