### PR TITLE
one off error in shortener

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/Utils.php
+++ b/phpmyfaq/src/phpMyFAQ/Utils.php
@@ -178,7 +178,7 @@ class Utils
         $num = count($arrStr);
 
         if ($num > $char) {
-            for ($j = 0; $j <= $char; ++$j) {
+            for ($j = 0; $j < $char; ++$j) {
                 $shortStr .= $arrStr[$j].' ';
             }
             $shortStr .= '...';


### PR DESCRIPTION
To Test: attempt to shorten a FAQ name with 9 words.  The new link in the right panel will also be nine words long, but suffixed with a "...".  This fix makes the new link 8 words plus the "...". 

Found in 2.9; ported to 3.0. 