### PR TITLE
change type in mapping for ES6 Support

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/Instance/Elasticsearch.php
+++ b/phpmyfaq/src/phpMyFAQ/Instance/Elasticsearch.php
@@ -62,22 +62,22 @@ class Elasticsearch
                     'type' => 'integer'
                 ],
                 'question' => [
-                    'type' => 'string',
+                    'type' => 'text',
                     'analyzer' => 'autocomplete',
                     'search_analyzer' => 'standard'
                 ],
                 'answer' => [
-                    'type' => 'string',
+                    'type' => 'text',
                     'analyzer' => 'autocomplete',
                     'search_analyzer' => 'standard'
                 ],
                 'keywords' => [
-                    'type' => 'string',
+                    'type' => 'text',
                     'analyzer' => 'autocomplete',
                     'search_analyzer' => 'standard'
                 ],
                 'categories' => [
-                    'type' => 'string',
+                    'type' => 'text',
                     'analyzer' => 'autocomplete',
                     'search_analyzer' => 'standard'
                 ]


### PR DESCRIPTION
Actually ES6 does not provide the the handler "string" anymore which causes an error while creating the index. Using text or keyword is now recommended:
https://github.com/elastic/elasticsearch-dsl-py/issues/804

This fixes the search, but there is still message Elasticsearch: No such index in Admin. I'm using the most actual ES6 version (fresh install).

