### PR TITLE
search exact word for content

### DIFF
--- a/phpmyfaq/inc/PMF/Search/Database.php
+++ b/phpmyfaq/inc/PMF/Search/Database.php
@@ -321,10 +321,18 @@ class PMF_Search_Database extends PMF_Search_Abstract implements PMF_Search_Inte
                 if ($j != 0) {
                     $where = $where.' OR ';
                 }
+                 if ($this->matchingColumns[$j] === 'fd.content') {
+                        $where = sprintf("%s%s LIKE ' %%%s%% '",
+                    $where,
+                    $this->matchingColumns[$j],
+                    $this->_config->getDb()->escape($keys[$i]));
+
+                }else{
                 $where = sprintf("%s%s LIKE '%%%s%%'",
                     $where,
                     $this->matchingColumns[$j],
                     $this->_config->getDb()->escape($keys[$i]));
+                }
             }
             $where .= ')';
         }

--- a/phpmyfaq/inc/PMF/Search/Database.php
+++ b/phpmyfaq/inc/PMF/Search/Database.php
@@ -327,7 +327,7 @@ class PMF_Search_Database extends PMF_Search_Abstract implements PMF_Search_Inte
                     $this->matchingColumns[$j],
                     $this->_config->getDb()->escape($keys[$i]));
 
-                }else{
+                } else {
                 $where = sprintf("%s%s LIKE '%%%s%%'",
                     $where,
                     $this->matchingColumns[$j],


### PR DESCRIPTION
Hello,

Linked to [https://forum.phpmyfaq.de/viewtopic.php?f=2&t=19228](https://forum.phpmyfaq.de/viewtopic.php?f=2&t=19228). If the content contains a picture, encoding causes wrong search results.

example : src="data:image/png;base64,mfn2s60aSPF9.... contains SPF word.

Please check if there is no side effect with this patch.