### PR TITLE
Fix activate user doesn't send email issue

### DIFF
--- a/phpmyfaq/admin/ajax.user.php
+++ b/phpmyfaq/admin/ajax.user.php
@@ -78,7 +78,6 @@ if ($user->perm->checkRight($user->getUserId(), 'add_user') ||
             }
 
             $user->getUserById($userId, true);
-            $user->setStatus('active');
             $user->activateUser();
             $http->sendJsonWithHeaders($user->getStatus());
             break;


### PR DESCRIPTION
When, in admin, you activate an user, the mail for the user with password doesn't send.
This i sbecause we change user status before activate it.
Removing the line 

`$this->setStatus('active');`

fixes this.

Hope it helps :-)