### PR TITLE
fix: missing dbport on multi-site creation

### DIFF
--- a/phpmyfaq/admin/ajax.config.php
+++ b/phpmyfaq/admin/ajax.config.php
@@ -91,6 +91,7 @@ switch ($ajaxAction) {
 
             $dbSetup = [
                 'dbServer' => $DB['server'],
+                'dbPort' => $DB['port'],
                 'dbUser' => $DB['user'],
                 'dbPassword' => $DB['password'],
                 'dbDatabaseName' => $DB['db'],


### PR DESCRIPTION
When creating a new multi-site instance, the port isn't written to the newly created database.php file.
As there seems to be no default port handling (3306) this results in an error message.