### PR TITLE
Check add_faq permission

### DIFF
--- a/phpmyfaq/add.php
+++ b/phpmyfaq/add.php
@@ -31,6 +31,13 @@ if (!defined('IS_VALID_PHPMYFAQ')) {
 // Check user permissions
 if ((-1 === $user->getUserId() && !$faqConfig->get('records.allowNewFaqsForGuests'))) {
     header('Location:' . $faqSystem->getSystemUri($faqConfig) . '?action=login');
+    exit;
+}
+
+// Check permission to add new faqs
+if (!$user->perm->checkRight($user->getUserId(), 'add_faq')) {
+    header('Location:' . $faqSystem->getSystemUri($faqConfig));
+    exit;
 }
 
 $captcha = new Captcha($faqConfig);

--- a/phpmyfaq/add.php
+++ b/phpmyfaq/add.php
@@ -29,7 +29,7 @@ if (!defined('IS_VALID_PHPMYFAQ')) {
 }
 
 // Check user permissions
-if ((-1 === $user->getUserId() && !$faqConfig->get('records.allowNewFaqsForGuests'))) {
+if (-1 === $user->getUserId() && !$faqConfig->get('records.allowNewFaqsForGuests')) {
     header('Location:' . $faqSystem->getSystemUri($faqConfig) . '?action=login');
     exit;
 }

--- a/phpmyfaq/add.php
+++ b/phpmyfaq/add.php
@@ -35,7 +35,7 @@ if ((-1 === $user->getUserId() && !$faqConfig->get('records.allowNewFaqsForGuest
 }
 
 // Check permission to add new faqs
-if (!$user->perm->checkRight($user->getUserId(), 'add_faq')) {
+if (-1 !== $user->getUserId() && !$user->perm->checkRight($user->getUserId(), 'addfaq')) {
     header('Location:' . $faqSystem->getSystemUri($faqConfig));
     exit;
 }


### PR DESCRIPTION
The ``add_faq`` permission should be checked in ``add.php``. Otherwise the option ``add_faq`` has no effect and users can create FAQs without permission.