### PR TITLE
Fix visibility flag in 'savequestion' action.

### DIFF
--- a/phpmyfaq/ajaxservice.php
+++ b/phpmyfaq/ajaxservice.php
@@ -477,9 +477,9 @@ switch ($action) {
                 Strings::htmlspecialchars($question)
             )) {
             if ($faqConfig->get('records.enableVisibilityQuestions')) {
-                $visibility = 'N';
-            } else {
                 $visibility = 'Y';
+            } else {
+                $visibility = 'N';
             }
 
             $questionData = [


### PR DESCRIPTION
The visibility flag was mixed-up when saving questions.