### PR TITLE
Use getAnswerId() method.

### DIFF
--- a/phpmyfaq/admin/record.questions.php
+++ b/phpmyfaq/admin/record.questions.php
@@ -96,7 +96,7 @@ if (!defined('IS_VALID_PHPMYFAQ')) {
                       </a>
                     </td>
                     <td>
-                        <?php if ($faqConfig->get('records.enableCloseQuestion') && $openQuestion['answer_id']) { ?>
+                        <?php if ($faqConfig->get('records.enableCloseQuestion') && $openQuestion->getAnswerId()) { ?>
                         <a href="?action=editentry&amp;id=<?= $openQuestion->getAnswerId() ?>&amp;lang=<?= $faqLangCode ?>"
                            class="btn btn-success">
                             <?= $PMF_LANG['msg2answerFAQ'] ?>


### PR DESCRIPTION
The variable `$openQuestion` does not have an element called `answer_id`. The `getAnswerId()` method should be used instead. Otherwise the php script will stop in the foreach-loop and only the first entry will be displayed.