### PR TITLE
Fixed missing seq on table creation

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/Instance/Database/Pgsql.php
+++ b/phpmyfaq/src/phpMyFAQ/Instance/Database/Pgsql.php
@@ -283,7 +283,7 @@ class Pgsql extends Database implements Driver
             PRIMARY KEY (id, lang))',
 
         'faqsections' => 'CREATE TABLE %sfaqsections (
-            id INTEGER NOT NULL,
+            id SERIAL NOT NULL,
             name VARCHAR(255) NOT NULL,
             description VARCHAR(255) DEFAULT NULL,
             PRIMARY KEY (id))',


### PR DESCRIPTION
If table already exists a manual creation is needed (or in an update step)