### PR TITLE
Feature request: HTML-support for contactInformations

### DIFF
--- a/phpmyfaq/contact.php
+++ b/phpmyfaq/contact.php
@@ -47,7 +47,9 @@ $template->parse(
     'mainPageContent',
     [
         'pageHeader' => Translation::get('msgContact'),
-        'msgContactOwnText' => nl2br(Strings::htmlspecialchars($faqConfig->get('main.contactInformations'))),
+        'msgContactOwnText' => 
+        ($faqConfig->get('main.contactInformationsHTML') === true) ? html_entity_decode($faqConfig->get('main.contactInformations')) : 
+        nl2br(Strings::htmlspecialchars($faqConfig->get('main.contactInformations'))),
         'msgContactEMail' => Translation::get('msgContactEMail'),
         'msgContactPrivacyNote' => Translation::get('msgContactPrivacyNote'),
         'privacyURL' => Strings::htmlentities($faqConfig->get('main.privacyURL')),

--- a/phpmyfaq/lang/language_de.php
+++ b/phpmyfaq/lang/language_de.php
@@ -1338,4 +1338,7 @@ $PMF_LANG['msgSubCategoryContent'] = 'Wähle eine Hauptkategorie aus.';
 $PMF_LANG['ad_open_question_deleted'] = 'Die Frage wurde erfolgreich gelöscht.';
 $LANG_CONF['mail.remoteSMTPDisableTLSPeerVerification'] = ['checkbox', 'SMTP TLS Peer Verifizierung deaktivieren (nicht empfohlen)'];
 
+// added v3.2.0-beta.2 - 2023-05-03 by Jan
+$LANG_CONF['main.contactInformationsHTML'] = ['checkbox', 'Kontaktinformationen/Impressum als HTML?'];
+
 return $PMF_LANG;

--- a/phpmyfaq/lang/language_en.php
+++ b/phpmyfaq/lang/language_en.php
@@ -1339,4 +1339,7 @@ $PMF_LANG['msgSubCategoryContent'] = 'Select a main category.';
 $PMF_LANG['ad_open_question_deleted'] = 'The question was successfully deleted.';
 $LANG_CONF['mail.remoteSMTPDisableTLSPeerVerification'] = ['checkbox', 'Disable SMTP TLS peer verification (not recommended)'];
 
+// added v3.2.0-beta.2 - 2023-05-03 by Jan
+$LANG_CONF['main.contactInformationsHTML'] = ['checkbox', 'Contact information as HTML?'];
+
 return $PMF_LANG;

--- a/phpmyfaq/setup/update.php
+++ b/phpmyfaq/setup/update.php
@@ -398,6 +398,9 @@ if ($step == 3) {
     if (version_compare($version, '3.2.0-beta', '<')) {
         $faqConfig->add('mail.remoteSMTPDisableTLSPeerVerification', false);
         $faqConfig->delete('main.enableLinkVerification');
+        
+        // HTML-support for contactInformations
+        $faqConfig->add('main.contactInformationsHTML', false);
 
         // Delete link verification columns
         $query[] = 'ALTER TABLE ' . $prefix . 'faqdata DROP COLUMN links_state, DROP COLUMN links_check_date';

--- a/phpmyfaq/src/phpMyFAQ/Setup/Installer.php
+++ b/phpmyfaq/src/phpMyFAQ/Setup/Installer.php
@@ -351,6 +351,7 @@ class Installer extends Setup
         'security.loginWithEmailAddress' => 'false',
         'main.enableAskQuestions' => 'false',
         'main.enableNotifications' => 'false',
+        'main.contactInformationsHTML' => 'false',
 
         'records.numberOfRecordsPerPage' => '10',
         'records.numberOfShownNewsEntries' => '3',


### PR DESCRIPTION
Hi Thorsten, 
this will add HTML-support for showing the contactInformations. It will insert a new configuration-item that can be checked if the contact informations should be formatted with HTML. 

The only problem which I see would be that the checkbox for this is not just underneath the text area for the contact-informations, but I didn't find a good solution for this. If you want to, you would have to check that again.