### PR TITLE
fix: corrected query() response

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/Database/Pgsql.php
+++ b/phpmyfaq/src/phpMyFAQ/Database/Pgsql.php
@@ -104,6 +104,10 @@ class Pgsql implements DatabaseDriver
             $this->sqllog .= $this->error();
         }
 
+        if (pg_result_status($result) == PGSQL_COMMAND_OK) {
+            return true;
+        }
+
         return $result;
     }
 


### PR DESCRIPTION
PostgreSQL and MySQL have different return types when executing query.
When using PostgreSQL, some methods will generate an error because the return types do not match.

Example)
phpMyFAQ\User\CurrentUser::setRememberMe()
phpMyFAQQuestion::updateQuestionAnswer()

So we fixed it to return true if the query does not return data on successful execution.