### PR TITLE
Feat: Rewrite success mail for new question

### DIFF
--- a/phpmyfaq/lang/language_de.php
+++ b/phpmyfaq/lang/language_de.php
@@ -1327,5 +1327,6 @@ $PMF_LANG['msgAuthenticationSource'] = 'Auth-Dienst';
 
 // added v3.2.0-RC - 2023-05-27 by Jan
 $LANG_CONF['spam.mailAddressInExport'] = ['checkbox', 'E-Mail-Adresse im Export anzeigen'];
+$PMF_LANG['msgNewQuestionAdded'] = 'Es wurde eine neue Frage hinzugefügt. Sie können diese hier oder im Adminbereich überprüfen:';
 
 return $PMF_LANG;

--- a/phpmyfaq/lang/language_en.php
+++ b/phpmyfaq/lang/language_en.php
@@ -1347,5 +1347,6 @@ $PMF_LANG['msgAuthenticationSource'] = 'Authentication service';
 
 // added v3.2.0-RC - 2023-05-27 by Jan
 $LANG_CONF['spam.mailAddressInExport'] = ['checkbox', 'Show email address in exports'];
+$PMF_LANG['msgNewQuestionAdded'] = 'A new question was added. You can check them here or in the admin section:';
 
 return $PMF_LANG;

--- a/phpmyfaq/src/phpMyFAQ/Helper/QuestionHelper.php
+++ b/phpmyfaq/src/phpMyFAQ/Helper/QuestionHelper.php
@@ -52,7 +52,7 @@ class QuestionHelper
             $questionData['username'] .
             ', ' . $questionData['email'] . "\n" . Translation::get('msgCategory') .
             ': ' . $categories[$questionData['category_id']]['name'] . "\n\n" .
-            Translation::get('msgAskYourQuestion') . ': ' . 
+            Translation::get('msgAskYourQuestion') . ': ' .
             wordwrap((string) $questionData['question'], 72) . "\n\n" .
             $this->config->getDefaultUrl() . 'admin/';
 

--- a/phpmyfaq/src/phpMyFAQ/Helper/QuestionHelper.php
+++ b/phpmyfaq/src/phpMyFAQ/Helper/QuestionHelper.php
@@ -48,9 +48,11 @@ class QuestionHelper
         $questionObject = new Question($this->config);
         $questionObject->addQuestion($questionData);
 
-        $questionMail = 'User: ' . $questionData['username'] .
-            ', mailto:' . $questionData['email'] . "\n" . Translation::get('msgCategory') .
+        $questionMail = Translation::get('msgNewQuestionAdded') . "\n\n User: " .
+            $questionData['username'] .
+            ', ' . $questionData['email'] . "\n" . Translation::get('msgCategory') .
             ': ' . $categories[$questionData['category_id']]['name'] . "\n\n" .
+            Translation::get('msgAskYourQuestion') . ': ' . 
             wordwrap((string) $questionData['question'], 72) . "\n\n" .
             $this->config->getDefaultUrl() . 'admin/';
 


### PR DESCRIPTION
The mail which is sent when a new question was added is a bit more understandable. I just added some messages.