### PR TITLE
Fix :Issuance of Category ID

### DIFF
--- a/phpmyfaq/admin/category.main.php
+++ b/phpmyfaq/admin/category.main.php
@@ -123,7 +123,7 @@ if (!defined('IS_VALID_PHPMYFAQ')) {
                     exit();
                 }
 
-                $categoryId = $category->addCategory($categoryData, $parentId);
+                $categoryId = $category->addCategory($categoryData, $parentId, $categoryId);
 
                 if ($categoryId) {
                     $categoryPermission->add(CategoryPermission::USER, [$categoryId], $permissions['restricted_user']);


### PR DESCRIPTION
When using PostgreSQL, the following problems exist

・Category IDs are issued twice by the sequence.
・The category ID does not match the ID in the category image file.

Therefore, we have modified to register categories using the issued category IDs.