### PR TITLE
Fix: pgsql search

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/Search/Database/Pgsql.php
+++ b/phpmyfaq/src/phpMyFAQ/Search/Database/Pgsql.php
@@ -32,8 +32,9 @@ class Pgsql extends SearchDatabase implements DatabaseInterface
     /**
      * Constructor.
      */
-    public function __construct()
+    public function __construct(Configuration $config)
     {
+        parent::__construct($config);
         $this->relevanceSupport = true;
     }
 


### PR DESCRIPTION
If you are using PostgreSQL, the search is currently not available.
Therefore, the error has been corrected to eliminate it.