### PR TITLE
fix: delete iOS-app link

### DIFF
--- a/phpmyfaq/assets/themes/default/templates/index.html
+++ b/phpmyfaq/assets/themes/default/templates/index.html
@@ -13,7 +13,6 @@
     <meta content="phpMyFAQ {{ phpmyfaqVersion }}" name="application-name" />
     <meta content="{{ metaRobots }}" name="robots" />
     <meta content="7 days" name="revisit-after" />
-    <meta content="app-id=977896957" name="apple-itunes-app" />
 
     <link href="{{ baseHref }}assets/dist/styles.css" rel="stylesheet" />
 


### PR DESCRIPTION
I would propose to delete the meta-tag which links to the phpMyFAQ-App in iOS because the app does not work for the 3.-versions. 