### PR TITLE
Fix:faq registration

### DIFF
--- a/phpmyfaq/admin/record.add.php
+++ b/phpmyfaq/admin/record.add.php
@@ -244,7 +244,7 @@ if ($user->perm->hasPermission($user->getUserId(), 'add_faq')) {
             (() => {
               setTimeout(() => {
                 window.location = "index.php?action=editentry&id=<?= $recordId;
-                    ?>&lang=<?= $recordData['lang'] ?>";
+                    ?>&lang=<?= $faqData->getLanguage() ?>";
               }, 5000);
             })();
             </script>


### PR DESCRIPTION
After registering a new FAQ, there was a bug that caused the category to be unselected when moving to the FAQ edit screen.
The cause was that lang was being acquired from an undefined array.
Therefore, this defect will be corrected.