### PR TITLE
Fix: faq-date-end

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/Entity/FaqEntity.php
+++ b/phpmyfaq/src/phpMyFAQ/Entity/FaqEntity.php
@@ -222,7 +222,7 @@ class FaqEntity
         if ($this->validTo instanceof DateTime) {
             return $this->validTo;
         } else {
-            return $this->validTo = new DateTime();
+            return $this->validTo = new DateTime('99991231235959');
         }
     }
 


### PR DESCRIPTION
When I update a FAQ, the publication end date is overwritten by the update date.
Therefore, the updated FAQ answers cannot be viewed on the public site side.
Therefore, we modified it to specify the default value.