### PR TITLE
Fix: category parameter name

### DIFF
--- a/phpmyfaq/search.php
+++ b/phpmyfaq/search.php
@@ -218,7 +218,7 @@ $mostPopularSearchData = $faqSearch->getMostPopularSearches($faqConfig->get('sea
 // Set base URL scheme
 if ($faqConfig->get('main.enableRewriteRules')) {
     $baseUrl = sprintf(
-        '%ssearch.html?search=%s&amp;seite=%d%s&amp;searchcategory=%d',
+        '%ssearch.html?search=%s&amp;seite=%d%s&amp;pmf-search-category=%d',
         $faqConfig->getDefaultUrl(),
         urlencode($inputSearchTerm),
         $page,
@@ -227,7 +227,7 @@ if ($faqConfig->get('main.enableRewriteRules')) {
     );
 } else {
     $baseUrl = sprintf(
-        '%s?%saction=search&amp;search=%s&amp;seite=%d%s&amp;searchcategory=%d',
+        '%s?%saction=search&amp;search=%s&amp;seite=%d%s&amp;pmf-search-category=%d',
         $faqConfig->getDefaultUrl(),
         empty($sids) ? '' : 'sids=' . $sids . '&amp;',
         urlencode($inputSearchTerm),


### PR DESCRIPTION
The search criteria for a category is lost after a paging transition on the search screen.
This phenomenon is caused by incorrect parameter names when paging.
Therefore, we have corrected the parameter names when setting paging.