### PR TITLE
Fix: Send notification mail for added question via api

### DIFF
--- a/phpmyfaq/api.php
+++ b/phpmyfaq/api.php
@@ -623,6 +623,13 @@ switch ($action) {
         $questionObject = new Question($faqConfig);
         $questionObject->addQuestion($questionData);
 
+        $categoryObject = new Category($faqConfig);
+        $categoryObject->getCategoryData($categoryId);
+        $categories = $categoryObject->getAllCategories();
+
+        $questionHelper = new QuestionHelper($faqConfig, $categoryObject);
+        $questionHelper->sendSuccessMail($questionData, $categories);
+
         $response->setData(['stored' => true]);
         break;
 }


### PR DESCRIPTION
Let the category owner and the admin be informed when a new question was added via REST API.

In the long run, the sendSuccessMail()-function which is in the class QuestionHelper() currently should better be integrated into Notification() to use SMTP as well if required.