### PR TITLE
Fix update problems with 2FA

### DIFF
--- a/phpmyfaq/setup/update.php
+++ b/phpmyfaq/setup/update.php
@@ -348,9 +348,9 @@ if ($step == 3) {
                 ADD COLUMN code_verifier VARCHAR(255) NULL DEFAULT NULL,
                 ADD COLUMN jwt TEXT NULL DEFAULT NULL;';
 
-            $query[] = 'ALTER TABLE ' . $prefix . "faquserdata
+            $query[] = 'ALTER TABLE ' . $prefix . 'faquserdata
                 ADD COLUMN twofactor_enabled INT(1) NULL DEFAULT 0,
-                ADD COLUMN secret VARCHAR(128) '' DEFAULT ''";
+                ADD COLUMN secret VARCHAR(128) NULL DEFAULT NULL';
         } else {
             $query[] = 'ALTER TABLE ' . $prefix . 'faquser 
                 ADD refresh_token TEXT NULL DEFAULT NULL,
@@ -358,9 +358,9 @@ if ($step == 3) {
                 ADD code_verifier VARCHAR(255) NULL DEFAULT NULL,
                 ADD jwt TEXT NULL DEFAULT NULL;';
 
-            $query[] = 'ALTER TABLE ' . $prefix . "faquserdata
+            $query[] = 'ALTER TABLE ' . $prefix . 'faquserdata
                 ADD twofactor_enabled INT(1) NULL DEFAULT 0,
-                ADD secret VARCHAR(128) DEFAULT ''";
+                ADD secret VARCHAR(128) NULL';
         }
 
         // New backup

--- a/phpmyfaq/setup/update.php
+++ b/phpmyfaq/setup/update.php
@@ -348,9 +348,9 @@ if ($step == 3) {
                 ADD COLUMN code_verifier VARCHAR(255) NULL DEFAULT NULL,
                 ADD COLUMN jwt TEXT NULL DEFAULT NULL;';
 
-            $query[] = 'ALTER TABLE ' . $prefix . 'faquserdata
+            $query[] = 'ALTER TABLE ' . $prefix . "faquserdata
                 ADD COLUMN twofactor_enabled INT(1) NULL DEFAULT 0,
-                ADD COLUMN secret VARCHAR(128) NULL DEFAULT NULL';
+                ADD COLUMN secret VARCHAR(128) '' DEFAULT ''";
         } else {
             $query[] = 'ALTER TABLE ' . $prefix . 'faquser 
                 ADD refresh_token TEXT NULL DEFAULT NULL,
@@ -358,9 +358,9 @@ if ($step == 3) {
                 ADD code_verifier VARCHAR(255) NULL DEFAULT NULL,
                 ADD jwt TEXT NULL DEFAULT NULL;';
 
-            $query[] = 'ALTER TABLE ' . $prefix . 'faquserdata
+            $query[] = 'ALTER TABLE ' . $prefix . "faquserdata
                 ADD twofactor_enabled INT(1) NULL DEFAULT 0,
-                ADD secret VARCHAR(128) NULL';
+                ADD secret VARCHAR(128) DEFAULT ''";
         }
 
         // New backup

--- a/phpmyfaq/setup/update.php
+++ b/phpmyfaq/setup/update.php
@@ -360,7 +360,7 @@ if ($step == 3) {
 
             $query[] = 'ALTER TABLE ' . $prefix . 'faquserdata
                 ADD twofactor_enabled INT(1) NULL DEFAULT 0,
-                ADD secret VARCHAR(128) NULL';
+                ADD secret VARCHAR(128) NULL DEFAULT NULL';
         }
 
         // New backup

--- a/phpmyfaq/src/phpMyFAQ/Instance/Database/Mysqli.php
+++ b/phpmyfaq/src/phpMyFAQ/Instance/Database/Mysqli.php
@@ -335,7 +335,7 @@ class Mysqli extends Database implements Driver
             email VARCHAR(128) NULL,
             is_visible INT(1) NULL DEFAULT 0,
             twofactor_enabled INT(1) NULL DEFAULT 0,
-            secret VARCHAR(128) NULL DEFAULT NULL',
+            secret VARCHAR(128) NULL DEFAULT NULL)',
 
         'faquserlogin' => 'CREATE TABLE %sfaquserlogin (
             login VARCHAR(128) NOT NULL,

--- a/phpmyfaq/src/phpMyFAQ/Instance/Database/Mysqli.php
+++ b/phpmyfaq/src/phpMyFAQ/Instance/Database/Mysqli.php
@@ -335,7 +335,7 @@ class Mysqli extends Database implements Driver
             email VARCHAR(128) NULL,
             is_visible INT(1) NULL DEFAULT 0,
             twofactor_enabled INT(1) NULL DEFAULT 0,
-            secret VARCHAR(128) NULL)',
+            secret VARCHAR(128) NULL DEFAULT NULL',
 
         'faquserlogin' => 'CREATE TABLE %sfaquserlogin (
             login VARCHAR(128) NOT NULL,

--- a/phpmyfaq/src/phpMyFAQ/Instance/Database/Pgsql.php
+++ b/phpmyfaq/src/phpMyFAQ/Instance/Database/Pgsql.php
@@ -330,7 +330,7 @@ class Pgsql extends Database implements Driver
             email VARCHAR(128) NULL,
             is_visible SMALLINT NULL DEFAULT 0,
             twofactor_enabled SMALLINT NULL DEFAULT 0,
-            secret VARCHAR(128) NULL)',
+            secret VARCHAR(128) NULL DEFAULT NULL)',
 
         'faquserlogin' => 'CREATE TABLE %sfaquserlogin (
             login VARCHAR(128) NOT NULL,

--- a/phpmyfaq/src/phpMyFAQ/Instance/Database/Sqlite3.php
+++ b/phpmyfaq/src/phpMyFAQ/Instance/Database/Sqlite3.php
@@ -329,7 +329,7 @@ class Sqlite3 extends Database implements Driver
             email VARCHAR(128) NULL,
             is_visible INT(1) NULL DEFAULT 0,
             twofactor_enabled INT(1) NULL DEFAULT 0,
-            secret VARCHAR(128) NULL)',
+            secret VARCHAR(128) NULL DEFAULT NULL)',
 
         'faquserlogin' => 'CREATE TABLE %sfaquserlogin (
             login VARCHAR(128) NOT NULL,

--- a/phpmyfaq/src/phpMyFAQ/Instance/Database/Sqlsrv.php
+++ b/phpmyfaq/src/phpMyFAQ/Instance/Database/Sqlsrv.php
@@ -329,7 +329,7 @@ class Sqlsrv extends Database implements Driver
             email NVARCHAR(128) NULL,
             is_visible INTEGER NULL DEFAULT 0,
             twofactor_enabled INTEGER NULL DEFAULT 0,
-            secret NVARCHAR(128) NULL)',
+            secret NVARCHAR(128) NULL DEFAULT NULL)',
 
         'faquserlogin' => 'CREATE TABLE %sfaquserlogin (
             login NVARCHAR(128) NOT NULL,

--- a/phpmyfaq/src/phpMyFAQ/User/TwoFactor.php
+++ b/phpmyfaq/src/phpMyFAQ/User/TwoFactor.php
@@ -59,7 +59,7 @@ class TwoFactor
     /**
      * Returns the secret of the current user
      */
-    public function getSecret(CurrentUser $user): string
+    public function getSecret(CurrentUser $user): string|null
     {
         return $user->getUserData('secret');
     }

--- a/phpmyfaq/ucp.php
+++ b/phpmyfaq/ucp.php
@@ -50,7 +50,7 @@ if ($user->isLoggedIn()) {
     
     $tfa = new TwoFactor($faqConfig);
     $secret = $tfa->getSecret(CurrentUser::getFromSession($faqConfig));
-    if ($secret === '') {
+    if (is_null($secret) {
         try {
             $secret = $tfa->generateSecret();
         } catch (TwoFactorAuthException $e) {


### PR DESCRIPTION
This option is much easier than the other one, I'm sorry. 
Now, we can be sure that the secret coloumn is null at every time.
Fix #2517 