### PR TITLE
Fix: index registration

### DIFF
--- a/phpmyfaq/admin/record.add.php
+++ b/phpmyfaq/admin/record.add.php
@@ -200,8 +200,8 @@ if ($user->perm->hasPermission($user->getUserId(), 'add_faq')) {
                         'id' => $recordId,
                         'lang' => $recordLang,
                         'solution_id' => $solutionId,
-                        'question' => $recordData['thema'],
-                        'answer' => $recordData['content'],
+                        'question' => $faqData->getQuestion(),
+                        'answer' => $faqData->getAnswer(),
                         'keywords' => $keywords,
                         'category_id' => $categories['rubrik'][0]
                     ]


### PR DESCRIPTION
The value specified when registering the Elasticsearch index is incorrect and has been corrected.
This is the same as previously fixed here.
https://github.com/thorsten/phpMyFAQ/pull/2485
