### PR TITLE
Fix: pgsql syntax

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/Instance/Database/Pgsql.php
+++ b/phpmyfaq/src/phpMyFAQ/Instance/Database/Pgsql.php
@@ -57,7 +57,7 @@ class Pgsql extends Database implements Driver
             PRIMARY KEY (virtual_hash))',
 
         'faqbackup' => 'CREATE TABLE %sfaqbackup (
-            id INT(11) NOT NULL,
+            id INTEGER NOT NULL,
             filename VARCHAR(255) NOT NULL,
             authkey VARCHAR(255) NOT NULL,
             authcode VARCHAR(255) NOT NULL,


### PR DESCRIPTION
The method of specifying numeric types is not Pgsql's, and has been corrected.