### PR TITLE
Fix admin search faqs

### DIFF
--- a/API.md
+++ b/API.md
@@ -52,6 +52,7 @@ be acquired from the admin configuration.
 ### FAQ related APIs
 
 - [Add FAQ](api-docs/faq/post.md): `POST /api/v2.2/faq`
+- [Update FAQ](api-docs/faq/put.md): `PUT /api/v2.2/faq/:categoryId/:faqId`
 - [Add question](api-docs/question/post.md): `POST /api/v2.2/question`
 
 ### Groups related APIs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# phpMyFAQ 3.2.0
+# phpMyFAQ 3.2.0-RC.3
 
 **Codename "Pontus"**
 
@@ -6,7 +6,7 @@
 
 This is a log of major user-visible changes in each phpMyFAQ release.
 
-### phpMyFAQ v3.2.0 - 2023-07-
+### phpMyFAQ v3.2.0-RC.3 - 2023-07-21
 
 - changed PHP requirement to PHP 8.1.0 or later (Thorsten)
 - changed to HTTPS as new default (Thorsten)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# phpMyFAQ 3.2.0-RC.3
+# phpMyFAQ 3.2.0
 
 **Codename "Pontus"**
 
@@ -6,7 +6,7 @@
 
 This is a log of major user-visible changes in each phpMyFAQ release.
 
-### phpMyFAQ v3.2.0-RC.3 - 2023-07-21
+### phpMyFAQ v3.2.0 - 2023-08-
 
 - changed PHP requirement to PHP 8.1.0 or later (Thorsten)
 - changed to HTTPS as new default (Thorsten)
@@ -19,7 +19,7 @@ This is a log of major user-visible changes in each phpMyFAQ release.
 - added 2FA (Two-Factor Authentication) (Jan Harms)
 - added experimental Azure AD login (Thorsten)
 - added option to use Google ReCaptcha (Thorsten)
-- added REST API v2.2 to fetch groups and add categories (Thorsten)
+- added REST API v2.2 to fetch groups, add categories, and update FAQs (Thorsten)
 - added verification of backup files (Thorsten)
 - added option to disable questions and notifications (Thorsten)
 - added new options for more flexibility (Jan Harms)

--- a/api-docs/faq/put.md
+++ b/api-docs/faq/put.md
@@ -1,6 +1,6 @@
-# Add a FAQ
+# Update a FAQ
 
-Used to add a new FAQ in one existing category.
+Used to update a FAQ in one existing category.
 
 **URL** : `/api/v2.1/faq`
 
@@ -20,9 +20,9 @@ Content-Type: application/json
 
 ```json
 {
+  "faq-id": "[faq id as integer value, required value]",
   "language": "[language code, required value]",
   "category-id": "[category id as integer value, required value]",
-  "category-name": "[category name in plain text, optional value]",
   "question": "[question in plain text, required value]",
   "answer": "[question in plain text, required value]",
   "keywords": "[keywords in comma separated plain text or empty string, required value]",
@@ -33,16 +33,13 @@ Content-Type: application/json
 }
 ```
 
-The category ID is a required value, the category name is optional. If the category name is present and the ID can be
-mapped, the category ID from the name will be used. If the category name cannot be mapped, a 409 error is thrown
-
 **Data example**
 
 ```json
 {
+  "faq-id": 1,
   "language": "de",
   "category-id": 1,
-  "category-name": "Queen Songs",
   "question": "Is this the world we created?",
   "answer": "What did we do it for, is this the world we invaded, against the law, so it seems in the end, is this what we're all living for today",
   "keywords": "phpMyFAQ, FAQ, Foo, Bar",
@@ -55,7 +52,7 @@ mapped, the category ID from the name will be used. If the category name cannot 
 
 ## Success Response
 
-**Condition** : If all posted data is correct.
+**Condition** : If all putted data is correct.
 
 **Code** : `200 OK`
 
@@ -69,9 +66,9 @@ mapped, the category ID from the name will be used. If the category name cannot 
 
 ## Error Responses
 
-**Condition** : If category name cannot be mapped to a valid ID
+**Condition** : If FAQ ID or category id cannot be mapped to valid IDs
 
-**Code** : `409 Conflict`
+**Code** : `404 Not Found`
 
 **Content** :
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thorsten/phpmyfaq",
-  "version": "3.2.0",
+  "version": "3.2.0-RC.3",
   "description": "phpMyFAQ",
   "repository": "git://github.com/thorsten/phpMyFAQ.git",
   "author": "Thorsten Rinne",

--- a/phpmyfaq/admin/record.show.php
+++ b/phpmyfaq/admin/record.show.php
@@ -164,7 +164,7 @@ if ($user->perm->hasPermission($user->getUserId(), 'edit_faq') || $user->perm->h
                 ]
             );
 
-        if (is_numeric($searchTerm)) {
+        if (is_numeric($searchTerm) && $faqConfig->get('search.searchForSolutionId')) {
             $search->setMatchingColumns([$fdTable . '.solution_id']);
         } else {
             $search->setMatchingColumns([$fdTable . '.thema', $fdTable . '.content', $fdTable . '.keywords']);

--- a/phpmyfaq/api.php
+++ b/phpmyfaq/api.php
@@ -30,6 +30,7 @@ use phpMyFAQ\Faq;
 use phpMyFAQ\Faq\FaqMetaData;
 use phpMyFAQ\Faq\FaqPermission;
 use phpMyFAQ\Filter;
+use phpMyFAQ\Helper\QuestionHelper;
 use phpMyFAQ\Helper\RegistrationHelper;
 use phpMyFAQ\Language;
 use phpMyFAQ\News;

--- a/phpmyfaq/src/phpMyFAQ/System.php
+++ b/phpmyfaq/src/phpMyFAQ/System.php
@@ -51,7 +51,7 @@ class System
     /**
      * Pre-release version.
      */
-    private const VERSION_PRE_RELEASE = '';
+    private const VERSION_PRE_RELEASE = 'RC.3';
 
     /**
      * API version.

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 if [ "x${PMF_VERSION}" = "x" ]; then
-    PMF_VERSION="3.2.0"
+    PMF_VERSION="3.2.0-RC.3"
 fi


### PR DESCRIPTION
With Search by Solution ID turned off, I am getting an error when I enter a numerical value to search for a FAQ in the admin area.
This is because it is executing an inappropriate query syntax for the faqdata.solution_id column.
Therefore, we have modified the search to search against faqdata.solution_id only when search by solution ID is turned on.