### PR TITLE
Fix: admin-search-faqs

### DIFF
--- a/phpmyfaq/admin/record.show.php
+++ b/phpmyfaq/admin/record.show.php
@@ -164,7 +164,7 @@ if ($user->perm->hasPermission($user->getUserId(), 'edit_faq') || $user->perm->h
                 ]
             );
 
-        if (is_numeric($searchTerm)) {
+        if (is_numeric($searchTerm) && $faqConfig->get('search.searchForSolutionId')) {
             $search->setMatchingColumns([$fdTable . '.solution_id']);
         } else {
             $search->setMatchingColumns([$fdTable . '.thema', $fdTable . '.content', $fdTable . '.keywords']);


### PR DESCRIPTION
With Search by Solution ID turned off, I am getting an error when I enter a numerical value to search for a FAQ in the admin area.
This is because it is executing an inappropriate query syntax for the faqdata.solution_id column.
Therefore, we have modified the search to search against faqdata.solution_id only when search by solution ID is turned on.
