### PR TITLE
Fix: tagid-type-error

### DIFF
--- a/phpmyfaq/search.php
+++ b/phpmyfaq/search.php
@@ -103,7 +103,7 @@ if ('' !== $inputTag) {
     $tagHelper->setTaggingIds($tagIds);
 
     foreach ($tagIds as $tagId) {
-        if (!isset($tags[$tagId])) {
+        if (!isset($tags[$tagId]) && is_numeric($tagId)) {
             $tags[$tagId] = $tagging->getTagNameById($tagId);
         }
     }


### PR DESCRIPTION
FatalError occurs when a string is passed as a parameter to a tag search.
The reason is that a string is passed as an argument that is supposed to be a numeric type.
Fix to check if it is a numeric type and get the tag name only if it is a numeric type.