### PR TITLE
Fix: faqid-type-error

### DIFF
--- a/phpmyfaq/faq.php
+++ b/phpmyfaq/faq.php
@@ -75,7 +75,7 @@ if ($showCaptcha !== '') {
 $currentCategory = $cat;
 
 $request = Request::createFromGlobals();
-$faqId = Filter::filterVar($request->query->get('id'), FILTER_VALIDATE_INT);
+$faqId = Filter::filterVar($request->query->get('id'), FILTER_VALIDATE_INT, 0);
 $solutionId = Filter::filterVar($request->query->get('solution_id'), FILTER_VALIDATE_INT);
 $highlight = Filter::filterVar($request->query->get('highlight'), FILTER_SANITIZE_SPECIAL_CHARS);
 

--- a/phpmyfaq/index.php
+++ b/phpmyfaq/index.php
@@ -332,8 +332,8 @@ $currentPageUrl = Strings::htmlentities($faqLink->getCurrentUrl());
 //
 // Found a record ID?
 //
-$id = Filter::filterVar($request->query->get('id'), FILTER_VALIDATE_INT);
-if (!is_null($id)) {
+$id = Filter::filterVar($request->query->get('id'), FILTER_VALIDATE_INT, 0);
+if ($id !== 0) {
     $faq->getRecord($id);
     $title = ' - ' . $faq->faqRecord['title'];
     $keywords = ',' . $faq->faqRecord['keywords'];
@@ -350,7 +350,6 @@ if (!is_null($id)) {
     $faqLink->itemTitle = $faq->faqRecord['title'];
     $currentPageUrl = $faqLink->toString(true);
 } else {
-    $id = '';
     $title = ' - ' . System::getPoweredByString();
     $keywords = '';
     $metaDescription = str_replace('"', '', (string) $faqConfig->get('main.metaDescription'));


### PR DESCRIPTION
FatalError occurs when a string is passed as the id parameter.
The reason was that a string was passed to an argument that was supposed to be numeric.

The default value for retrieving the value of the id parameter is now set to 0.
If the default value is not set, null will be set and a type error will occur.
The $id must always be numeric.