### PR TITLE
fix: added missing bracket for setup querys

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/Instance/Database/Mysqli.php
+++ b/phpmyfaq/src/phpMyFAQ/Instance/Database/Mysqli.php
@@ -65,7 +65,7 @@ class Mysqli extends Database implements Driver
 
         'faqbookmarks' => 'CREATE TABLE %sfaqbookmarks (
             userid INT(11) DEFAULT NULL,
-            faqid INT(11) DEFAULT NULL',
+            faqid INT(11) DEFAULT NULL) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB',
 
         'faqcaptcha' => 'CREATE TABLE %sfaqcaptcha (
             id VARCHAR(6) NOT NULL,


### PR DESCRIPTION
Setup was not possible, so I added a missing bracket to fix the query