### PR TITLE
Fix: rememberme input field

### DIFF
--- a/phpmyfaq/admin/login.php
+++ b/phpmyfaq/admin/login.php
@@ -75,7 +75,7 @@ if ($request->isSecure() || !$faqConfig->get('security.useSslForLogins')) {
                                             </span>
                                         </div>
                                         <div class="form-check mb-3">
-                                            <input class="form-check-input" id="faqrememberme" type="checkbox"
+                                            <input class="form-check-input" id="faqrememberme" name="faqrememberme" type="checkbox"
                                                    value="rememberMe" />
                                             <label class="form-check-label"
                                                    for="faqrememberme"><?= Translation::get('rememberMe') ?></label>


### PR DESCRIPTION
Because the name attribute of "remember me" was not specified, the post value could not be obtained.
Therefore, the name attribute has been modified to be specified.