### PR TITLE
Fix: copyentry tags

### DIFF
--- a/phpmyfaq/admin/record.edit.php
+++ b/phpmyfaq/admin/record.edit.php
@@ -188,6 +188,7 @@ if (
         $faq->getRecord($faqData['id'], null, true);
 
         $faqData = $faq->faqRecord;
+        $faqData['tags'] = implode(', ', $tagging->getAllTagsById($faqData['id']));
         $queryString = 'insertentry';
     } else {
         $logging = new AdminLog($faqConfig);


### PR DESCRIPTION
Tag data was not copied when creating a copy of the FAQ.
Therefore, it was corrected to retrieve the tag information from the source of the copy.