### PR TITLE
Fix: remove nl2br

### DIFF
--- a/phpmyfaq/admin/record.save.php
+++ b/phpmyfaq/admin/record.save.php
@@ -137,7 +137,7 @@ if ($user->perm->hasPermission($user->getUserId(), 'edit_faq')) {
 
         // Create ChangeLog entry
         $changelog = new Changelog($faqConfig);
-        $changelog->add($recordId, $user->getUserId(), nl2br((string) $changed), $recordLang, $revisionId);
+        $changelog->add($recordId, $user->getUserId(), (string) $changed, $recordLang, $revisionId);
 
         // Create the visit entry
         $visits = new Visits($faqConfig);


### PR DESCRIPTION
The revision history data is registered in the DB after inserting line break tags with "nl2br()".
However, since the data was converted by "htmlentities()" when output to the screen, it was output as a string.
"nl2br()" was removed as unnecessary.