### PR TITLE
Fix: system menu entry

### DIFF
--- a/phpmyfaq/admin/header.php
+++ b/phpmyfaq/admin/header.php
@@ -110,7 +110,7 @@ $secLevelEntries['exports'] = $adminHelper->addMenuEntry('export', 'export', 'ad
 $secLevelEntries['backup'] = $adminHelper->addMenuEntry('editconfig', 'backup', 'ad_menu_backup', $action);
 
 $secLevelEntries['config'] = $adminHelper->addMenuEntry('editconfig', 'config', 'ad_menu_editconfig', $action);
-$secLevelEntries['config'] .= $adminHelper->addMenuEntry('editconfig', 'system', 'ad_system_info', $action, false);
+$secLevelEntries['config'] .= $adminHelper->addMenuEntry('editconfig', 'system', 'ad_system_info', $action);
 $secLevelEntries['config'] .= $adminHelper->addMenuEntry(
     'editinstances+addinstances+delinstances',
     'instances',


### PR DESCRIPTION
Currently, even if you do not have the "edit config" authority, the system information items are displayed in the side menu.
However, if the user does not have the "edit config" authority, the user will receive an error message when navigating to this item.
Therefore, we propose that the system information item should not be displayed in the side menu if the user does not have the "edit config" privilege.