### PR TITLE
Fix: revision display

### DIFF
--- a/phpmyfaq/admin/record.edit.php
+++ b/phpmyfaq/admin/record.edit.php
@@ -330,7 +330,7 @@ if (
                             <div class="tab-pane active" id="tab-question-answer">
                                 <!-- Revision -->
                                 <?php
-                                if ($user->perm->hasPermission($currentUserId, 'changebtrevs')) {
+                                if ($user->perm->hasPermission($currentUserId, 'changebtrevs') && $action === 'editentry') {
                                     $faqRevision = new Revision($faqConfig);
                                     $revisions = $faqRevision->get($faqData['id'], $faqData['lang'], $faqData['author']);
                                     if (count($revisions)) { ?>


### PR DESCRIPTION
When I create a copy of an FAQ, if the copy source has revised data, a selection item for the revised data appears on the copy creation form.
When this item is selected, the user is redirected to the original FAQ edit form.
We believe that this specification may cause users to make mistakes in making revisions.
Therefore, we have modified it so that the selection item for revision data is displayed only when editing FAQs.