### PR TITLE
Fix: tag suggest

### DIFF
--- a/phpmyfaq/admin/assets/src/content/tags.js
+++ b/phpmyfaq/admin/assets/src/content/tags.js
@@ -110,14 +110,15 @@ export const handleTags = () => {
       input: tagsAutocomplete,
       minLength: 1,
       onSelect: async (item, input) => {
-        let currentTags = input.getAttribute('data-tag-list');
+        let currentTags = input.value;
+        let currentTagsArray = currentTags.split(',');
         if (currentTags.length === 0) {
           currentTags = item.tagName;
         } else {
-          currentTags = currentTags + ', ' + item.tagName;
+          currentTagsArray[currentTagsArray.length-1] = item.tagName;
+          currentTags = currentTagsArray.join(',');
         }
         input.value = currentTags;
-        input.setAttribute('data-tag-list', currentTags);
       },
       fetch: async (text, callback) => {
         let match = text.toLowerCase();

--- a/phpmyfaq/admin/record.edit.php
+++ b/phpmyfaq/admin/record.edit.php
@@ -513,8 +513,7 @@ if (
                                     <div class="col-lg-10">
                                         <input type="text" name="tags" id="tags" value="<?= $faqData['tags'] ?>"
                                                autocomplete="off"
-                                               class="form-control pmf-tags-autocomplete"
-                                               data-tag-list="<?= $faqData['tags'] ?>">
+                                               class="form-control pmf-tags-autocomplete">
                                         <small id="tagsHelp"
                                                class="form-text visually-hidden"><?= Translation::get('msgShowHelp') ?></small>
                                     </div>


### PR DESCRIPTION
When I select a tag from the suggestions in the tag input field, the tag I entered disappears.
The reason is that the "data-tag-list" attribute value is acquired when selecting a suggestion.
To resolve this issue, we have modified it to retrieve the value of the input field.
With this modification, the value selected in the suggestion will be displayed in the same way as the existing behavior.