### PR TITLE
Fix: faqdata_tags error

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/Tags.php
+++ b/phpmyfaq/src/phpMyFAQ/Tags.php
@@ -110,6 +110,7 @@ class Tags
     public function saveTags(int $recordId, array $tags): bool
     {
         $currentTags = $this->getAllTags();
+        $registeredTags = [];
 
         // Delete all tag references for the faq record
         if (count($tags) > 0) {
@@ -119,7 +120,7 @@ class Tags
         // Store tags and references for the faq record
         foreach ($tags as $tagName) {
             $tagName = trim($tagName);
-            if (Strings::strlen($tagName) > 0) {
+            if (Strings::strlen($tagName) > 0 && !in_array($tagName, $registeredTags, true)) {
                 if (
                     !in_array(
                         Strings::strtolower($tagName),
@@ -156,6 +157,7 @@ class Tags
                     );
                 }
                 $this->config->getDb()->query($query);
+                $registeredTags[] = $tagName;
             }
         }
 


### PR DESCRIPTION
When I try to enter and save multiple tags with the same name, I get an SQL syntax error.
The reason is that the same id is being registered in the faqdata_tags table.
Therefore, a simple check for registered tags is now performed when registering to the DB.