### PR TITLE
Fix: default email

### DIFF
--- a/phpmyfaq/admin/record.add.php
+++ b/phpmyfaq/admin/record.add.php
@@ -67,7 +67,7 @@ if ($user->perm->hasPermission($user->getUserId(), 'add_faq')) {
     $content = Filter::filterInput(INPUT_POST, 'answer', FILTER_SANITIZE_SPECIAL_CHARS);
     $keywords = Filter::filterInput(INPUT_POST, 'keywords', FILTER_SANITIZE_SPECIAL_CHARS);
     $author = Filter::filterInput(INPUT_POST, 'author', FILTER_SANITIZE_SPECIAL_CHARS);
-    $email = Filter::filterInput(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
+    $email = Filter::filterInput(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL, '');
     $comment = Filter::filterInput(INPUT_POST, 'comment', FILTER_SANITIZE_SPECIAL_CHARS);
     $recordId = Filter::filterInput(INPUT_POST, 'id', FILTER_VALIDATE_INT);
     $solutionId = Filter::filterInput(INPUT_POST, 'solution_id', FILTER_VALIDATE_INT);

--- a/phpmyfaq/admin/record.save.php
+++ b/phpmyfaq/admin/record.save.php
@@ -74,7 +74,7 @@ if ($user->perm->hasPermission($user->getUserId(), 'edit_faq')) {
     $content = Filter::filterInput(INPUT_POST, 'answer', FILTER_SANITIZE_SPECIAL_CHARS);
     $keywords = Filter::filterInput(INPUT_POST, 'keywords', FILTER_SANITIZE_SPECIAL_CHARS);
     $author = Filter::filterInput(INPUT_POST, 'author', FILTER_SANITIZE_SPECIAL_CHARS);
-    $email = Filter::filterInput(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
+    $email = Filter::filterInput(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL, '');
     $comment = Filter::filterInput(INPUT_POST, 'comment', FILTER_SANITIZE_SPECIAL_CHARS);
     $recordId = Filter::filterInput(INPUT_POST, 'record_id', FILTER_VALIDATE_INT);
     $solutionId = Filter::filterInput(INPUT_POST, 'solution_id', FILTER_VALIDATE_INT);


### PR DESCRIPTION
FatalError occurred when the email address was not entered when saving the FAQ.
The cause is that null is passed as an argument of type string. It seems that null is returned if the email address is not in the format of an email address due to the filter function.
Therefore, the filter function has been modified to set a default value.