### PR TITLE
Fix: duplicate htmlentities for question

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/Faq.php
+++ b/phpmyfaq/src/phpMyFAQ/Faq.php
@@ -2407,7 +2407,7 @@ class Faq
         if (count($result) > 0) {
             foreach ($result as $row) {
                 $output['title'][] = Utils::makeShorterText(Strings::htmlentities($row['question']), 8);
-                $output['preview'][] = Strings::htmlentities(Strings::htmlentities($row['question']));
+                $output['preview'][] = Strings::htmlentities($row['question']);
                 $output['url'][] = Strings::htmlentities($row['url']);
             }
         } else {


### PR DESCRIPTION
The most recent commit was modified to do htmlentities() where htmlentities() was already done.
However, we do not believe that htmlentities() needs to be performed in duplicate.
Therefore, we have corrected the duplicate locations. If you have any particular reason for this, please let me know.
