### PR TITLE
Fix: integer overflow

### DIFF
--- a/phpmyfaq/admin/stat.main.php
+++ b/phpmyfaq/admin/stat.main.php
@@ -74,7 +74,7 @@ $request = Request::createFromGlobals();
             // Delete sessions and session files
             if ($statdelete == 'delete' && $month !== '') {
                 $dir = opendir(PMF_ROOT_DIR . '/data');
-                $first = 9999999999999999999;
+                $first = PHP_INT_MAX;
                 $last = 0;
                 while ($trackingFile = readdir($dir)) {
                     // The filename format is: trackingDDMMYYYY
@@ -124,7 +124,7 @@ $request = Request::createFromGlobals();
             <td>
                 <?php
                 $danz = 0;
-                $first = 9999999999999999999999999;
+                $first = PHP_INT_MAX;
                 $last = 0;
                 $dir = opendir(PMF_ROOT_DIR . '/data');
                 while ($dat = readdir($dir)) {


### PR DESCRIPTION
An error due to int type overflow was occurring in the "View Session" screen.
When there is no session file, "9999999999999999999" is specified as the initial value of timestamp.
However, if the int type exceeds the upper limit, it is interpreted as a float type.
As a result, a float type value is passed to an int type and an error occurs.
Therefore, the upper limit of the int type has been corrected so that the upper limit of the int type is passed.