### PR TITLE
Fix: report category items

### DIFF
--- a/phpmyfaq/admin/report.view.php
+++ b/phpmyfaq/admin/report.view.php
@@ -16,6 +16,7 @@
  * @since     2011-01-12
  */
 
+use phpMyFAQ\Category;
 use phpMyFAQ\Filter;
 use phpMyFAQ\Language\LanguageCodes;
 use phpMyFAQ\Report;
@@ -78,11 +79,17 @@ if ($user->perm->hasPermission($user->getUserId(), 'reports')) {
     <?php
 
     $report = new Report($faqConfig);
+    $category = new Category($faqConfig);
+    $allCategories = $category->getAllCategories();
 
     foreach ($report->getReportingData() as $data) {
         echo '<tr>';
         if ($useCategory) {
-            printf('<td>%s</td>', Strings::htmlentities($data['category_name'] ?? ''));
+            if (0 != $data['category_parent']) {
+                printf('<td>%s</td>', Strings::htmlentities($allCategories[$data['category_parent']]['name'] ?? ''));
+            } else {
+                printf('<td>%s</td>', Strings::htmlentities($data['category_name'] ?? ''));
+            }
         }
         if ($useSubcategory) {
             if (0 != $data['category_parent']) {


### PR DESCRIPTION
Currently, the same value is displayed for category and subcategory items in the report function.
Therefore, we have modified the report function to display the parent category name if there is a parent category.