### PR TITLE
Fix: searchterm maxlength

### DIFF
--- a/phpmyfaq/assets/themes/default/templates/404.html
+++ b/phpmyfaq/assets/themes/default/templates/404.html
@@ -81,6 +81,7 @@
                 id="pmf-search-autocomplete"
                 name="search"
                 placeholder="{{ searchBox }} ..."
+                maxlength="255"
                 value="{{ searchTerm }}"
               />
               <button type="submit" class="btn btn-info btn-lg">{{ searchBox }}</button>

--- a/phpmyfaq/assets/themes/default/templates/index.html
+++ b/phpmyfaq/assets/themes/default/templates/index.html
@@ -80,6 +80,7 @@
                 id="pmf-search-autocomplete"
                 name="search"
                 placeholder="{{ searchBox }} ..."
+                maxlength="255"
                 value="{{ searchTerm }}"
               />
               <button type="submit" class="btn btn-info btn-lg">{{ searchBox }}</button>

--- a/phpmyfaq/assets/themes/default/templates/search.html
+++ b/phpmyfaq/assets/themes/default/templates/search.html
@@ -10,7 +10,7 @@
         <div class="row">
           <div class="col-6">
             <label class="sr-only" for="searchfield">{{ msgSearch }}</label>
-            <input id="searchfield" type="search" name="search" value="{{ searchString }}"
+            <input id="searchfield" type="search" name="search" maxlength="255" value="{{ searchString }}"
               class="form-control form-control-lg mb-2" placeholder="{{ msgSearch }}">
           </div>
 

--- a/phpmyfaq/search.php
+++ b/phpmyfaq/search.php
@@ -52,7 +52,7 @@ $faq->setGroups($currentGroups);
 $request = Request::createFromGlobals();
 $inputLanguage = Filter::filterVar($request->query->get('pmf-all-languages'), FILTER_SANITIZE_SPECIAL_CHARS);
 $inputCategory = Filter::filterVar($request->query->get('pmf-search-category'), FILTER_VALIDATE_INT, '%');
-$inputSearchTerm = Filter::filterVar($request->query->get('search'), FILTER_SANITIZE_SPECIAL_CHARS);
+$inputSearchTerm = mb_substr(Filter::filterVar($request->query->get('search'), FILTER_SANITIZE_SPECIAL_CHARS), 0, 255);
 $inputTag = Filter::filterVar($request->query->get('tagging_id'), FILTER_SANITIZE_SPECIAL_CHARS);
 
 if (!is_null($inputTag)) {
@@ -60,7 +60,7 @@ if (!is_null($inputTag)) {
     $inputTag = str_replace(',,', ',', $inputTag);
 }
 
-$searchTerm = Filter::filterVar($request->request->get('search'), FILTER_SANITIZE_SPECIAL_CHARS);
+$searchTerm = mb_substr(Filter::filterVar($request->request->get('search'), FILTER_SANITIZE_SPECIAL_CHARS), 0, 255);
 $page = Filter::filterVar($request->query->get('seite'), FILTER_VALIDATE_INT, 1);
 
 // Search only on current language (default)

--- a/phpmyfaq/search.php
+++ b/phpmyfaq/search.php
@@ -52,7 +52,7 @@ $faq->setGroups($currentGroups);
 $request = Request::createFromGlobals();
 $inputLanguage = Filter::filterVar($request->query->get('pmf-all-languages'), FILTER_SANITIZE_SPECIAL_CHARS);
 $inputCategory = Filter::filterVar($request->query->get('pmf-search-category'), FILTER_VALIDATE_INT, '%');
-$inputSearchTerm = mb_substr(Filter::filterVar($request->query->get('search'), FILTER_SANITIZE_SPECIAL_CHARS), 0, 255);
+$inputSearchTerm = Strings::substr(Filter::filterVar($request->query->get('search'), FILTER_SANITIZE_SPECIAL_CHARS), 0, 255);
 $inputTag = Filter::filterVar($request->query->get('tagging_id'), FILTER_SANITIZE_SPECIAL_CHARS);
 
 if (!is_null($inputTag)) {
@@ -60,7 +60,7 @@ if (!is_null($inputTag)) {
     $inputTag = str_replace(',,', ',', $inputTag);
 }
 
-$searchTerm = mb_substr(Filter::filterVar($request->request->get('search'), FILTER_SANITIZE_SPECIAL_CHARS), 0, 255);
+$searchTerm = Strings::substr(Filter::filterVar($request->request->get('search'), FILTER_SANITIZE_SPECIAL_CHARS), 0, 255);
 $page = Filter::filterVar($request->query->get('seite'), FILTER_VALIDATE_INT, 1);
 
 // Search only on current language (default)


### PR DESCRIPTION
A DB error occurs when a keyword search is performed on a string of more than 255 characters.
This is because the limit of the searchterm column in the "faqsearches" table is exceeded.

Therefore, the following modifications have been made.
・Add "maxlength" to the attribute of the keyword input column.
・When acquiring the input value, the maximum length is 255 characters from the beginning.
