### PR TITLE
Fix: method of getting the num rows

### DIFF
--- a/phpmyfaq/search.php
+++ b/phpmyfaq/search.php
@@ -169,7 +169,7 @@ if ($inputSearchTerm !== '' || $searchTerm !== '') {
 
     foreach ($searchResults as $faqKey => $faqValue) {
         $checkedFaq = $faq->getRecordResult($faqValue->id, $faqValue->lang);
-        if (0 === $checkedFaq->num_rows) {
+        if (0 === $faqConfig->getDb()->numRows($checkedFaq)) {
             unset($searchResults[$faqKey]);
         }
     }


### PR DESCRIPTION
The number of rows is obtained with the num_rows property, which PostgreSQL does not have.
This property does not exist in PostgreSQL. num_rows is a property of the mysqli_result object.
Therefore, we modified it to numRows() defined in the DB class so that the number of rows can be obtained in other DBs.