### PR TITLE
fix: changed argument order due to #2967

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/User/TwoFactor.php
+++ b/phpmyfaq/src/phpMyFAQ/User/TwoFactor.php
@@ -43,11 +43,11 @@ readonly class TwoFactor
     {
         $this->qrCodeProvider = new EndroidQrCodeProvider();
         $this->twoFactorAuth = new TwoFactorAuth(
+            $this->qrCodeProvider,
             $this->configuration->get('main.metaPublisher'),
             6,
             30,
-            Algorithm::Sha1,
-            $this->qrCodeProvider
+            Algorithm::Sha1
         );
     }
 


### PR DESCRIPTION
Randomly, I discovered changed in the RobThree/TwoFactorAuth lib. Take a look at the [changelog](https://github.com/RobThree/TwoFactorAuth/blob/master/CHANGELOG.md). The QrCodeProvider is now a mandatory argument and due to this, the argument order is changed.