### PR TITLE
fix: show correct trending faqs on startpage

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/Faq/Statistics.php
+++ b/phpmyfaq/src/phpMyFAQ/Faq/Statistics.php
@@ -172,8 +172,6 @@ class Statistics
                 $entry->date = $date->format($row['date']);
                 $output[] = $entry;
             }
-        } else {
-            $output['error'] = Translation::get('err_noArticles');
         }
 
         return $output;


### PR DESCRIPTION
This is checked in twig; therefore this additional check isn't necessary