### PR TITLE
use bootstrap to make top/left navs sticky

### DIFF
--- a/phpmyfaq/assets/templates/admin/index.twig
+++ b/phpmyfaq/assets/templates/admin/index.twig
@@ -22,7 +22,7 @@
 <body dir="{{ pageDirection }}" id="page-top">
 
 <!-- phpMyFAQ Admin Top Bar -->
-<nav class="pmf-admin-topnav navbar navbar-expand text-bg-dark">
+<nav class="pmf-admin-topnav navbar navbar-expand text-bg-dark sticky-top">
   <a class="navbar-brand text-white text-center ps-3" href="../" title="phpMyFAQ {{ version }}">
     <img height="50" src="../assets/images/logo-transparent.svg" alt="phpMyFAQ Logo">
   </a>
@@ -96,7 +96,7 @@
     <div id="pmf-admin-layout-sidenav_nav">
       <nav class="pmf-admin-sidenav accordion pmf-admin-sidenav-dark" id="sidenavAccordion">
         <div class="pmf-admin-sidenav-menu mt-2">
-          <div class="nav">
+          <div class="nav sticky-top">
 
             <!-- Dashboard -->
             <a class="nav-link" href="./">

--- a/phpmyfaq/assets/templates/sven/admin.css
+++ b/phpmyfaq/assets/templates/sven/admin.css
@@ -1,0 +1,5 @@
+
+
+#sidenavAccordion div.sticky-top {
+  top: 65px;
+}


### PR DESCRIPTION
add bootstrap class to topnav and side nav.
positioning side nav accordeon to be fixed under the topnav (otherwise dashboard scrolls under topnav)