### PR TITLE
Redirect after login and last url

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/Application.php
+++ b/phpmyfaq/src/phpMyFAQ/Application.php
@@ -106,6 +106,9 @@ class Application
 
     private function handleRequest(RouteCollection $routeCollection, Request $request, RequestContext $context): void
     {
+        if ( ! preg_match('/login|authenticate|logout|keep-alive|token|check/', $request->getRequestUri()) ) {
+            $this->container->get('session')->set("lastRequestUri", $request->getRequestUri());
+        }
         $urlMatcher = new UrlMatcher($routeCollection, $context);
         $this->setUrlMatcher($urlMatcher);
         $controllerResolver = new ControllerResolver();
@@ -138,7 +141,7 @@ class Application
                     ['Content-Type' => 'application/json']
                 );
             } else {
-                $response = new RedirectResponse('/login');
+                $response = new RedirectResponse('../login');
             }
         } catch (BadRequestException $exception) {
             $response = new Response(

--- a/phpmyfaq/src/phpMyFAQ/Controller/Administration/AuthenticationController.php
+++ b/phpmyfaq/src/phpMyFAQ/Controller/Administration/AuthenticationController.php
@@ -70,7 +70,7 @@ class AuthenticationController extends AbstractAdministrationController
                     'Login-error\nLogin: ' . $username . '\nErrors: ' . implode(', ', $this->currentUser->errors)
                 );
                 //$error = $e->getMessage();
-                return new RedirectResponse('./login');
+                return new RedirectResponse('../login');
             }
         }
 


### PR DESCRIPTION
Ich habe es jetzt das
- wenn die Session abhaut im normalen FAQ Bereich (zb Meeting, dann komme ich zurück und drücke auf ein link):
      > redirect login
      > redirect zum ursprünglich angefahrenen URL (ausgenommen login/logout)

- wenn die abhaut im admin bereich
      > redirect nach ../login (anstatt Symfony login)
      > redirect zum ursprünglich angefahrenen URL (ausgenommen login/logout/authenticate/keep-alive)
     
Sollte der prev URL leer sein dann gehts zur homepage oder /admin 

endeffect: das symfony authentication wird umgangen... Meinung? 
