### PR TITLE
fix: use correct right term

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/Enums/PermissionType.php
+++ b/phpmyfaq/src/phpMyFAQ/Enums/PermissionType.php
@@ -38,7 +38,7 @@ enum PermissionType: string
 
     case EXPORT = 'export';
 
-    case FAQ_ADD = 'addfaq';
+    case FAQ_ADD = 'add_faq';
 
     case FAQ_APPROVE = 'approverec';
 


### PR DESCRIPTION
Hey Thorsten, 
this fixes a bug where a user which is not a super-admin but has the right to add faqs cannot see the menu entry to do so. This problem is related to a wrongly used term for the right to add faqs.
According to the database, it should be "add_faq" like it's fixed in this PR.