### PR TITLE
Updated index.twig to hide the simple search bar when already on a search results page.

### DIFF
--- a/phpmyfaq/assets/scss/layout/_theme-switcher.scss
+++ b/phpmyfaq/assets/scss/layout/_theme-switcher.scss
@@ -354,8 +354,6 @@
   a {
     color: var(--bs-primary);
     text-decoration: underline;
-    font-size: 1.3rem;
-    font-weight: 800;
 
     &:hover {
       color: var(--bs-dark);
@@ -364,6 +362,14 @@
       border-radius: 4px;
     }
   }
+
+  // Apply larger sizing only to main content links
+  .pmf-content a,
+  main a {
+    font-size: 1.3rem;
+    font-weight: 800;
+  }
+
   //Logo link exception - yellow border on hover & scale up for better visibility
   #phpmyfaq-logo {
     transform: scale(1.3);
@@ -386,8 +392,8 @@
   // Heading style exceptions
   h1.pmf-start-page,
   .pmf-start-page.h1 {
-    background:var(--bs-primary);
-    -webkit-background-clip:text;
+    background: var(--bs-primary);
+    -webkit-background-clip: text;
     background-clip: text;
     border: 3px dashed var(--bs-primary);
     border-radius: 8px;
@@ -562,7 +568,7 @@
 
     &:hover {
       background-color: var(--bs-primary);
-      color: #000!important;
+      color: #000 !important;
       border-radius: 5px;
     }
   }

--- a/phpmyfaq/assets/templates/default/index.twig
+++ b/phpmyfaq/assets/templates/default/index.twig
@@ -100,7 +100,7 @@
 </nav>
 
 <!-- SEARCH -->
-{% set isSearchPage = ('search.html' in currentPageUrl) or ('action=search' in currentPageUrl) %}
+{% set isSearchPage = (currentPageUrl matches '/\\/search\\.html([?#]|$)/') or (currentPageUrl matches '/[?&]action=search(&|$)/') %}
 {% if not isMaintenanceMode and not isSearchPage %}
 <div class="container my-5">
   <div class="row height d-flex justify-content-center align-items-center">


### PR DESCRIPTION
Updated index.twig to hide the simple search bar when already on a search results page. This prevents redundant search input options and streamlines the user experience, while keeping the advanced search functionality available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced dark/high-contrast theme: bolder search input and badges, stronger borders, adjusted link and heading sizing/spacing, and improved contrast across cards, footer, alerts, and content links.

* **Bug Fixes**
  * Search block suppressed on dedicated search pages and when the site is in maintenance mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->