### PR TITLE
fix: handling for search term

### DIFF
--- a/phpmyfaq/assets/templates/default/index.twig
+++ b/phpmyfaq/assets/templates/default/index.twig
@@ -105,7 +105,7 @@
   <div class="row height d-flex justify-content-center align-items-center">
     <div class="col-md-8">
       <div class="search">
-        <form action="./search.html" id="search" method="post" role="search">
+        <form action="./search.html" id="search" method="get" role="search">
           <i class="bi bi-search"></i>
           <input autocomplete="off" type="text" class="form-control form-control-lg" id="pmf-search-autocomplete"
                  name="search" placeholder="{{ searchBox }} ..." maxlength="255" value="{{ searchTerm }}">

--- a/phpmyfaq/search.php
+++ b/phpmyfaq/search.php
@@ -60,7 +60,7 @@ $plurals = new Plurals();
 $request = Request::createFromGlobals();
 $inputLanguage = Filter::filterVar($request->query->get('pmf-all-languages'), FILTER_SANITIZE_SPECIAL_CHARS);
 $inputCategory = Filter::filterVar($request->query->get('pmf-search-category'), FILTER_VALIDATE_INT, '%');
-$inputSearchTerm = Filter::filterVar($request->request->get('search'), FILTER_SANITIZE_SPECIAL_CHARS);
+$inputSearchTerm = Filter::filterVar($request->query->get('search'), FILTER_SANITIZE_SPECIAL_CHARS);
 $inputSearchTerm = Strings::substr($inputSearchTerm, 0, 255);
 $inputTag = Filter::filterVar($request->query->get('tagging_id'), FILTER_SANITIZE_SPECIAL_CHARS);
 


### PR DESCRIPTION
Unifying the search on form method="get" to make search results accessible for bookmarks and sharing via link. fix that results available on normal and advanced search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Search queries are now transmitted via URL parameters, making search results bookmarkable and shareable through the address bar.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->