### PR TITLE
Potential fix for code scanning alert no. 21: DOM text reinterpreted as HTML

### DIFF
--- a/phpmyfaq/assets/src/configuration/update.ts
+++ b/phpmyfaq/assets/src/configuration/update.ts
@@ -20,7 +20,11 @@ export const handleUpdateNextStepButton = (): void => {
   if (nextStepButton && nextStep) {
     nextStepButton.addEventListener('click', (event: MouseEvent): void => {
       event.preventDefault();
-      window.location.replace(`?step=${nextStep.value}`);
+      const stepValue = parseInt(nextStep.value, 10);
+      if (Number.isNaN(stepValue) || stepValue < 1) {
+        return;
+      }
+      window.location.replace(`?step=${stepValue}`);
     });
   }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/thorsten/phpMyFAQ/security/code-scanning/21](https://github.com/thorsten/phpMyFAQ/security/code-scanning/21)

In general, the problem is resolved by validating or sanitizing data read from the DOM before using it in security-sensitive contexts such as constructing URLs, HTML, or selectors. Here, `nextStep.value` should be constrained to the expected set of step identifiers (for example, positive integers) before interpolating it into the query string used with `window.location.replace`.

The best minimal fix that preserves existing functionality is to parse `nextStep.value` as an integer and ensure it is a valid, positive number before using it. If parsing fails or yields an invalid number, we can either abort navigation or fall back to a safe default (e.g. step 1). This ensures that characters which could significantly alter the URL structure (like `:` or `?`) are not propagated, because only digits are accepted. No new imports are needed.

Concretely, in `phpmyfaq/assets/src/configuration/update.ts`, within `handleUpdateNextStepButton`, replace the direct use of `` `?step=${nextStep.value}` `` with logic that:

1. Parses `nextStep.value` using `parseInt`.
2. Checks `Number.isNaN` and numeric bounds.
3. Constructs the URL using the sanitized numeric step.

Only the body of the click event listener needs changing; the rest of the file remains as is.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved step navigation validation to properly reject invalid or zero step values. Only valid numeric steps are now processed during navigation, enhancing reliability and preventing navigation errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->