### PR TITLE
Potential fix for code scanning alert no. 23: DOM text reinterpreted as HTML

### DIFF
--- a/phpmyfaq/admin/assets/src/content/attachment-upload.ts
+++ b/phpmyfaq/admin/assets/src/content/attachment-upload.ts
@@ -49,7 +49,7 @@ export const handleAttachmentUploads = (): void => {
         output = approx.toFixed(2) + ' ' + multiples[multiple] + ' (' + bytes + ' bytes)';
       }
 
-      fileSize.innerHTML = output;
+      fileSize.textContent = output;
       fileList.append(addElement('ul', { className: 'mt-2' }, fileItems));
     });
 
@@ -108,7 +108,7 @@ export const handleAttachmentUploads = (): void => {
           );
         });
 
-        fileSize.innerHTML = '';
+        fileSize.textContent = '';
         fileList.forEach((li: Element): void => {
           li.remove();
         });


### PR DESCRIPTION
Potential fix for [https://github.com/thorsten/phpMyFAQ/security/code-scanning/23](https://github.com/thorsten/phpMyFAQ/security/code-scanning/23)

In general, to fix DOM text reinterpreted as HTML, avoid assigning untrusted or non-HTML content to `innerHTML`. Instead, assign it to `textContent`/`innerText` or use DOM APIs to build elements, so the browser treats it strictly as text and not as markup.

Here, we never intend `output` to contain HTML—it's just a human-readable file size string. The best fix is:
- Replace `fileSize.innerHTML = output;` with `fileSize.textContent = output;`, so the value is inserted as plain text.
- Likewise, later when clearing the element, replace `fileSize.innerHTML = '';` with `fileSize.textContent = '';`. This keeps the pattern consistent and removes unnecessary use of `innerHTML`.

These changes are localized to `phpmyfaq/admin/assets/src/content/attachment-upload.ts`:
- Around line 52: change the assignment to use `textContent`.
- Around line 111: likewise change the clearing assignment to `textContent`.

No extra imports, methods, or definitions are needed; `textContent` is a standard property of `HTMLElement`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security handling of file size display in the attachment upload feature by ensuring text content is rendered as plain text rather than HTML.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->