### PR TITLE
fix: custom templates sources

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/System.php
+++ b/phpmyfaq/src/phpMyFAQ/System.php
@@ -247,7 +247,7 @@ class System
     public function getAvailableTemplates(): array
     {
         $templates = [];
-        $systemFolder = ['admin', 'setup'];
+        $systemFolder = ['admin', 'setup', 'error'];
 
         foreach (new DirectoryIterator(PMF_ROOT_DIR . '/assets/templates/') as $item) {
             $basename = $item->getBasename();


### PR DESCRIPTION
exclude error template folder from the "custom templates" menu in the layout-admin-menu