### PR TITLE
[Backport] [4.1] open-questions page

### DIFF
--- a/phpmyfaq/assets/templates/default/open-questions.twig
+++ b/phpmyfaq/assets/templates/default/open-questions.twig
@@ -1,54 +1,167 @@
 {% extends 'index.twig' %}
 
 {% block content %}
-<section class="col-12">
-  <h2 class="mb-4 border-bottom">{{ pageHeader }}</h2>
+<section class="col-12" aria-labelledby="page-header">
+  <h2 id="page-header" class="mb-4 border-bottom">{{ pageHeader }}</h2>
   <p>{{ msgQuestionText }}</p>
 
-  <table class="table table-striped align-middle mb-5">
-    <tr>
-      <th>{{ msgDate_User }}</th>
-      <th colspan="2">{{ msgQuestion2 }}</th>
-    </tr>
+  {% set showActionColumn = userHasPermissionToAnswer %}
+
+  {% if not showActionColumn and isCloseQuestionEnabled %}
+    {% for question in openQuestions.questions %}
+        {% if question.answerId > 0 %}
+            {% set showActionColumn = true %}
+        {% endif %}
+    {% endfor %}
+  {% endif %}
+
+  {% set totalColumns = showActionColumn ? 3 : 2 %}
+  {% set questionColspan = showActionColumn ? 2 : 1 %}
+
+  <div class="d-none d-md-block shadow rounded-2 overflow-hidden mb-5">
+    <div class="table-responsive">
+      <table class="table table-striped align-middle mb-0"{% if openQuestions.numberInvisibleQuestions > 0 %} aria-describedby="questions-info"{% endif %}>
+        <caption class="visually-hidden">{{ pageHeader }}</caption>
+        <colgroup>
+          <col style="width: 25%;">
+          {% if showActionColumn %}
+            <col style="width: 60%;">
+            <col style="width: 15%;">
+          {% else %}
+            <col style="width: 75%;">
+          {% endif %}
+        </colgroup>
+        <thead>
+          <tr class="border-bottom">
+            <th scope="col" class="ps-3 py-3">{{ msgDate_User }}</th>
+            <th scope="col" colspan="{{ questionColspan }}" class="py-3">{{ msgQuestion2 }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% if openQuestions.numberQuestions > 0 %}
+            {% for question in openQuestions.questions %}
+              <tr>
+                <td class="text-break small ps-3">
+                  <i class="bi bi-calendar-date me-1" aria-hidden="true"></i>{{ question.date }}<br>
+                  <a href="mailto:{{ question.email }}" title="{{ msgEmailTo }} {{ question.userName }}">
+                    <i class="bi bi-person me-1" aria-hidden="true"></i>{{ question.userName }}
+                  </a>
+                </td>
+                
+                <td class="text-break">
+                  <div class="d-flex align-items-center mb-1">
+                    <div style="width: 25px;" class="flex-shrink-0">
+                      <i class="bi bi-card-list text-muted" aria-hidden="true"></i>
+                    </div>
+                    <div class="flex-grow-1">
+                      <strong>{{ question.categoryName }}:</strong>
+                    </div>
+                  </div>
+                  <div class="d-flex align-items-start">
+                    <div style="width: 25px;" class="flex-shrink-0">
+                      <i class="bi bi-question-square text-muted" aria-hidden="true"></i>
+                    </div>
+                    <div class="flex-grow-1">
+                      <span>{{ question.question }}</span>
+                    </div>
+                  </div>
+                </td>
+
+                {% if showActionColumn %}
+                  <td class="text-end pe-3" style="white-space: nowrap;">
+                    {% if isCloseQuestionEnabled and question.answerId > 0 %}
+                      <a class="btn btn-primary" href="?action=faq&cat={{ question.categoryId }}&id={{ question.answerId }}">
+                        <i class="bi bi-check-circle me-1" aria-hidden="true"></i>{{ msg2answerFAQ }}
+                      </a>
+                    {% elseif userHasPermissionToAnswer %}
+                      <a class="btn btn-primary" href="?action=add&question={{ question.id }}&cat={{ question.categoryId }}">
+                        <i class="bi bi-chat-left-text me-1" aria-hidden="true"></i>{{ msg2answer }}
+                      </a>
+                    {% endif %}
+                  </td>
+                {% endif %}
+              </tr>
+            {% endfor %}
+          {% else %}
+            <tr>
+              <td colspan="{{ totalColumns }}" class="text-center py-4">{{ msgNoQuestionsAvailable }}</td>
+            </tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="d-md-none mb-5"{% if openQuestions.numberInvisibleQuestions > 0 %} aria-describedby="questions-info"{% endif %}>
     {% if openQuestions.numberQuestions > 0 %}
       {% for question in openQuestions.questions %}
-        <tr>
-          <td>
-            <small>{{ question.date }}</small><br><a href="mailto:{{ question.email }}">{{ question.userName }}</a>
-          </td>
-          <td>
-            <strong>{{ question.categoryName }}:</strong><br>{{ question.question }}
-          </td>
-          {% if isCloseQuestionEnabled and question.answerId > 0 %}
-            <td class="text-end">
-              <a class="btn btn-primary"  href="?action=faq&cat={{ question.categoryId }}&id={{ question.answerId }}">
-                {{ msg2answerFAQ }}
+        <div class="card shadow mb-4">
+          <div class="card-body">
+            <h5 class="card-title text-center mb-3">
+              <i class="bi bi-card-list text-warning" aria-hidden="true"></i>
+              <span class="text-warning">{{ question.categoryName }}</span>
+            </h5>
+
+            <div class="mb-3 small text-muted border-bottom pb-2">
+              <div class="d-flex align-items-center mb-1">
+                <div class="flex-shrink-0" style="width: 25px;">
+                  <i class="bi bi-calendar-date" aria-hidden="true"></i>
+                </div>
+                <div>{{ question.date }}</div>
+              </div>
+
+              <a href="mailto:{{ question.email }}" class="text-decoration-none text-muted d-flex align-items-center" title="{{ msgEmailTo }} {{ question.userName }}">
+                <div class="flex-shrink-0" style="width: 25px;">
+                  <i class="bi bi-person" aria-hidden="true"></i>
+                </div>
+                <div class="text-break">
+                  {{ question.userName }}
+                </div>
               </a>
-            </td>
-          {% elseif userHasPermissionToAnswer %}
-            <td class="text-end">
-              <a class="btn btn-primary" href="?action=add&question={{ question.id }}&cat={{ question.categoryId }}">
-                {{ msg2answer }}
-              </a>
-            </td>
-          {% else %}
-            <td class="text-end"></td>
-          {% endif %}
-        </tr>
+            </div>
+
+            <div class="card-text text-break mb-3 d-flex">
+              <div class="flex-shrink-0 me-2">
+                <i class="bi bi-question-square text-warning" aria-hidden="true"></i>
+              </div>
+              <div>
+                {{ question.question }}
+              </div>
+            </div>
+            
+            {% if showActionColumn %}
+              <div class="d-grid gap-2">
+                {% if isCloseQuestionEnabled and question.answerId > 0 %}
+                  <a class="btn btn-primary bg-gradient" href="?action=faq&cat={{ question.categoryId }}&id={{ question.answerId }}">
+                    <i class="bi bi-check-circle me-2" aria-hidden="true"></i>{{ msg2answerFAQ }}
+                  </a>
+                {% elseif userHasPermissionToAnswer %}
+                  <a class="btn btn-primary bg-gradient" href="?action=add&question={{ question.id }}&cat={{ question.categoryId }}">
+                    <i class="bi bi-chat-left-text me-2" aria-hidden="true"></i>{{ msg2answer }}
+                  </a>
+                {% endif %}
+              </div>
+            {% endif %}
+          </div>
+        </div>
       {% endfor %}
     {% else %}
-      <tr>
-        <td colspan="3">{{ msgNoQuestionsAvailable }}</td>
-      </tr>
+
+      <div class="card shadow mb-4">
+        <div class="card-body text-center py-4 text-muted">
+          <i class="bi bi-inbox mb-2 d-block h4" aria-hidden="true"></i>
+          {{ msgNoQuestionsAvailable }}
+        </div>
+      </div>
     {% endif %}
-    {% if openQuestions.numberInvisibleQuestions > 0 %}
-      <tr>
-        <td colspan="3">
-          {{ openQuestions.numberInvisibleQuestions }} {{ msgQuestionsWaiting }}
-        </td>
-      </tr>
-    {% endif %}
-  </table>
+  </div>
+
+  {% if openQuestions.numberInvisibleQuestions > 0 %}
+    <div id="questions-info" class="alert alert-light border border-primary text-muted fst-italic text-center mb-5" role="note">
+      <i class="bi bi-info-circle me-2" aria-hidden="true"></i>
+      <strong>{{ openQuestions.numberInvisibleQuestions }}</strong> {{ msgQuestionsWaiting }}
+    </div>
+  {% endif %}
 </section>
 
 {% endblock %}

--- a/phpmyfaq/open-questions.php
+++ b/phpmyfaq/open-questions.php
@@ -50,12 +50,14 @@ $templateVars = [
     'msgQuestion2' => Translation::get(key: 'msgQuestion2'),
     'openQuestions' => $questionHelper->getOpenQuestions(),
     'isCloseQuestionEnabled' => $faqConfig->get('records.enableCloseQuestion'),
-    'userHasPermissionToAnswer' => $user->perm->hasPermission($user->getUserId(), PermissionType::FAQ_ADD->value),
+    'userHasPermissionToAnswer' =>
+        $user->perm->hasPermission($user->getUserId(), PermissionType::FAQ_ADD->value)
+        || $faqConfig->get('records.allowNewFaqsForGuests'),
     'msgQuestionsWaiting' => Translation::get(key: 'msgQuestionsWaiting'),
     'msgNoQuestionsAvailable' => Translation::get(key: 'msgNoQuestionsAvailable'),
     'msg2answerFAQ' => Translation::get(key: 'msg2answerFAQ'),
     'msg2answer' => Translation::get(key: 'msg2answer'),
+    'msgEmailTo' => Translation::get(key: 'msgEmailTo'),
 ];
 
 return $templateVars;
-

--- a/phpmyfaq/translations/language_de.php
+++ b/phpmyfaq/translations/language_de.php
@@ -99,10 +99,11 @@ $PMF_LANG['msgAskCategory'] = "Kategorie";
 $PMF_LANG['msgAskYourQuestion'] = "Frage";
 $PMF_LANG['msgAskThx4Mail'] = "Vielen Dank für diese Anfrage.";
 $PMF_LANG['msgDate_User'] = "Datum / Verfasser";
-$PMF_LANG['msgQuestion2'] = "Frage";
+$PMF_LANG['msgQuestion2'] = "Kategorie / Frage";
 $PMF_LANG['msg2answer'] = "beantworten";
 $PMF_LANG['msgQuestionText'] = "Hier sind die Fragen anderer Nutzer zu sehen. Diese können hier beantwortet werden. Der Eintrag wird dadurch auch den FAQ-Beiträgen hinzugefügt.";
 $PMF_LANG['msgNoQuestionsAvailable'] = "Derzeit gibt es keine offenen Fragen.";
+$PMF_LANG['msgEmailTo'] = "E-Mail an";
 
 // Contact
 $PMF_LANG['msgContactEMail'] = "E-Mail an den Betreiber";

--- a/phpmyfaq/translations/language_en.php
+++ b/phpmyfaq/translations/language_en.php
@@ -98,10 +98,11 @@ $PMF_LANG["msgAskCategory"] = "Category";
 $PMF_LANG["msgAskYourQuestion"] = "Your question";
 $PMF_LANG["msgAskThx4Mail"] = "Thank you for your question!";
 $PMF_LANG["msgDate_User"] = "Date / User";
-$PMF_LANG["msgQuestion2"] = "Question";
+$PMF_LANG["msgQuestion2"] = "Category / Question";
 $PMF_LANG["msg2answer"] = "Answer";
 $PMF_LANG["msgQuestionText"] = "Here you can see questions asked by other users. If you answer these questions, your answers may be inserted into the FAQ.";
 $PMF_LANG["msgNoQuestionsAvailable"] = "Currently there are no pending questions.";
+$PMF_LANG["msgEmailTo"] = "Email to";
 
 // Contact
 $PMF_LANG["msgContactEMail"] = "Email the FAQ owner";


### PR DESCRIPTION
This is a backport of the improvements recently merged into #main (4.2) for the open-questions page. The implementation has been adapted to match the architecture of version 4.1

**Key Improvements:**
    Accessibility: Added semantic HTML5 table structure (thead, tbody, caption) and conditional ARIA attributes (aria-describedby) for better screen reader support.
    Responsive Design: Replaced squashed tables on small screens with a modern card-based mobile view.
    Logic Fix: Updated the permission check to properly include guests if records.allowNewFaqsForGuests is enabled.
    UI/UX: Aligned the visual style (shadows, icons, and layout) with the start page for a consistent user experience.
    High Contrast Mode: Fixed layout issues (empty columns) that previously disturbed the display in high contrast and dark modes.

**Changes in this PR:**
    Modified open-questions.php to pass the correct boolean values to Twig.
    Updated open-questions.twig with the new responsive and accessible structure.
    Updated language files (en and de) to include or adjust variables like msgQuestion2 to reflect the combined "Category / Question" column.

**Reference:**
Backport of [#3941]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced responsive card-based layout for open questions on mobile devices alongside desktop table view
  * Added permission-based conditional action buttons for answering or closing questions

* **Improvements**
  * Enhanced accessibility with aria labels and semantic markup
  * Expanded user permission paths for answering questions
  * Added empty-state messaging and informational banner for unanswered questions
  * Updated question labels to include category context

* **Localization**
  * Updated German and English translations for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->