### PR TITLE
feat: add granular group-based permissions with category restrictions

### DIFF
--- a/phpmyfaq/admin/assets/src/api/group.test.ts
+++ b/phpmyfaq/admin/assets/src/api/group.test.ts
@@ -1,9 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fetchAllGroups, fetchAllUsersForGroups, fetchAllMembers, fetchGroup, fetchGroupRights } from './group';
+import {
+  fetchAllGroups,
+  fetchAllUsersForGroups,
+  fetchAllMembers,
+  fetchGroup,
+  fetchGroupRights,
+  fetchGroupCategoryRestrictions,
+  saveGroupCategoryRestrictions,
+  fetchCategoriesForRestrictions,
+} from './group';
 import * as fetchWrapperModule from './fetch-wrapper';
 
 vi.mock('./fetch-wrapper', () => ({
   fetchJson: vi.fn(),
+  fetchWrapper: vi.fn(),
 }));
 
 describe('fetchAllGroups', () => {
@@ -162,5 +172,94 @@ describe('fetchGroupRights', () => {
     const groupId = '123';
 
     await expect(fetchGroupRights(groupId)).rejects.toThrow('Network response was not ok.');
+  });
+});
+
+describe('fetchGroupCategoryRestrictions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch category restrictions for a group', async () => {
+    const mockResponse = { '1': [10, 20], '3': [30] };
+    vi.spyOn(fetchWrapperModule, 'fetchJson').mockResolvedValue(mockResponse);
+
+    const groupId = '5';
+    const result = await fetchGroupCategoryRestrictions(groupId);
+
+    expect(result).toEqual(mockResponse);
+    expect(fetchWrapperModule.fetchJson).toHaveBeenCalledWith(`./api/group/category-restrictions/${groupId}`, {
+      method: 'GET',
+      cache: 'no-cache',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      redirect: 'follow',
+      referrerPolicy: 'no-referrer',
+    });
+  });
+
+  it('should throw an error if the network response is not ok', async () => {
+    vi.spyOn(fetchWrapperModule, 'fetchJson').mockRejectedValue(new Error('Network response was not ok.'));
+
+    await expect(fetchGroupCategoryRestrictions('5')).rejects.toThrow('Network response was not ok.');
+  });
+});
+
+describe('saveGroupCategoryRestrictions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should save category restrictions for a group right', async () => {
+    const mockResponse = { ok: true, status: 200 } as Response;
+    vi.spyOn(fetchWrapperModule, 'fetchWrapper').mockResolvedValue(mockResponse);
+
+    const result = await saveGroupCategoryRestrictions('5', '1', [10, 20]);
+
+    expect(result).toEqual(mockResponse);
+    expect(fetchWrapperModule.fetchWrapper).toHaveBeenCalledWith('./api/group/category-restrictions', {
+      method: 'POST',
+      cache: 'no-cache',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ groupId: 5, rightId: 1, categoryIds: [10, 20] }),
+      redirect: 'follow',
+      referrerPolicy: 'no-referrer',
+    });
+  });
+});
+
+describe('fetchCategoriesForRestrictions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch all categories for restriction picker', async () => {
+    const mockResponse = [
+      { id: 1, name: 'General', parent_id: 0 },
+      { id: 2, name: 'Technical', parent_id: 0 },
+    ];
+    vi.spyOn(fetchWrapperModule, 'fetchJson').mockResolvedValue(mockResponse);
+
+    const result = await fetchCategoriesForRestrictions();
+
+    expect(result).toEqual(mockResponse);
+    expect(fetchWrapperModule.fetchJson).toHaveBeenCalledWith('./api/group/categories', {
+      method: 'GET',
+      cache: 'no-cache',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      redirect: 'follow',
+      referrerPolicy: 'no-referrer',
+    });
+  });
+
+  it('should throw an error if the network response is not ok', async () => {
+    vi.spyOn(fetchWrapperModule, 'fetchJson').mockRejectedValue(new Error('Network response was not ok.'));
+
+    await expect(fetchCategoriesForRestrictions()).rejects.toThrow('Network response was not ok.');
   });
 });

--- a/phpmyfaq/admin/assets/src/api/group.test.ts
+++ b/phpmyfaq/admin/assets/src/api/group.test.ts
@@ -215,7 +215,7 @@ describe('saveGroupCategoryRestrictions', () => {
     const mockResponse = { ok: true, status: 200 } as Response;
     vi.spyOn(fetchWrapperModule, 'fetchWrapper').mockResolvedValue(mockResponse);
 
-    const result = await saveGroupCategoryRestrictions('5', '1', [10, 20]);
+    const result = await saveGroupCategoryRestrictions('5', '1', [10, 20], 'test-csrf-token');
 
     expect(result).toEqual(mockResponse);
     expect(fetchWrapperModule.fetchWrapper).toHaveBeenCalledWith('./api/group/category-restrictions', {
@@ -224,7 +224,7 @@ describe('saveGroupCategoryRestrictions', () => {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ groupId: 5, rightId: 1, categoryIds: [10, 20] }),
+      body: JSON.stringify({ groupId: 5, rightId: 1, categoryIds: [10, 20], csrfToken: 'test-csrf-token' }),
       redirect: 'follow',
       referrerPolicy: 'no-referrer',
     });

--- a/phpmyfaq/admin/assets/src/api/group.ts
+++ b/phpmyfaq/admin/assets/src/api/group.ts
@@ -13,8 +13,8 @@
  * @since     2023-01-02
  */
 
-import { Group, Member, User } from '../interfaces';
-import { fetchJson } from './fetch-wrapper';
+import { CategoryItem, CategoryRestrictions, Group, Member, User } from '../interfaces';
+import { fetchJson, fetchWrapper } from './fetch-wrapper';
 
 export const fetchAllGroups = async (): Promise<Group[]> => {
   return (await fetchJson('./api/group/groups', {
@@ -74,4 +74,45 @@ export const fetchGroupRights = async (groupId: string): Promise<string[]> => {
     redirect: 'follow',
     referrerPolicy: 'no-referrer',
   })) as string[];
+};
+
+export const fetchGroupCategoryRestrictions = async (groupId: string): Promise<CategoryRestrictions> => {
+  return (await fetchJson(`./api/group/category-restrictions/${groupId}`, {
+    method: 'GET',
+    cache: 'no-cache',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    redirect: 'follow',
+    referrerPolicy: 'no-referrer',
+  })) as CategoryRestrictions;
+};
+
+export const saveGroupCategoryRestrictions = async (
+  groupId: string,
+  rightId: string,
+  categoryIds: number[]
+): Promise<Response> => {
+  return await fetchWrapper('./api/group/category-restrictions', {
+    method: 'POST',
+    cache: 'no-cache',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ groupId: parseInt(groupId), rightId: parseInt(rightId), categoryIds }),
+    redirect: 'follow',
+    referrerPolicy: 'no-referrer',
+  });
+};
+
+export const fetchCategoriesForRestrictions = async (): Promise<CategoryItem[]> => {
+  return (await fetchJson('./api/group/categories', {
+    method: 'GET',
+    cache: 'no-cache',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    redirect: 'follow',
+    referrerPolicy: 'no-referrer',
+  })) as CategoryItem[];
 };

--- a/phpmyfaq/admin/assets/src/api/group.ts
+++ b/phpmyfaq/admin/assets/src/api/group.ts
@@ -91,7 +91,8 @@ export const fetchGroupCategoryRestrictions = async (groupId: string): Promise<C
 export const saveGroupCategoryRestrictions = async (
   groupId: string,
   rightId: string,
-  categoryIds: number[]
+  categoryIds: number[],
+  csrfToken: string
 ): Promise<Response> => {
   return await fetchWrapper('./api/group/category-restrictions', {
     method: 'POST',
@@ -99,7 +100,7 @@ export const saveGroupCategoryRestrictions = async (
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ groupId: parseInt(groupId), rightId: parseInt(rightId), categoryIds }),
+    body: JSON.stringify({ groupId: parseInt(groupId), rightId: parseInt(rightId), categoryIds, csrfToken }),
     redirect: 'follow',
     referrerPolicy: 'no-referrer',
   });

--- a/phpmyfaq/admin/assets/src/group/groups.ts
+++ b/phpmyfaq/admin/assets/src/group/groups.ts
@@ -399,6 +399,7 @@ export const handleCategoryRestrictionsSave = async (): Promise<void> => {
     return;
   }
 
+  const csrfToken = container.dataset.csrfToken || '';
   const selects = container.querySelectorAll<HTMLSelectElement>('select[data-right-id]');
 
   for (const select of selects) {
@@ -411,6 +412,6 @@ export const handleCategoryRestrictionsSave = async (): Promise<void> => {
       .filter((option: HTMLOptionElement): boolean => option.selected)
       .map((option: HTMLOptionElement): number => parseInt(option.value));
 
-    await saveGroupCategoryRestrictions(groupId, rightId, selectedCategoryIds);
+    await saveGroupCategoryRestrictions(groupId, rightId, selectedCategoryIds, csrfToken);
   }
 };

--- a/phpmyfaq/admin/assets/src/group/groups.ts
+++ b/phpmyfaq/admin/assets/src/group/groups.ts
@@ -338,7 +338,8 @@ const renderCategoryRestrictions = (container: HTMLElement): void => {
   container.innerHTML = '';
 
   if (checkedRights.length === 0) {
-    container.innerHTML = '<p class="text-muted">No permissions assigned to this group.</p>';
+    const emptyMsg = container.dataset.msgEmpty || 'No permissions assigned to this group.';
+    container.innerHTML = `<p class="text-muted">${emptyMsg}</p>`;
     return;
   }
 
@@ -373,7 +374,9 @@ const renderCategoryRestrictions = (container: HTMLElement): void => {
 
     const helpText = document.createElement('div');
     helpText.className = 'form-text';
-    helpText.textContent = 'Select categories to restrict this permission. Leave empty for unrestricted access.';
+    helpText.textContent =
+      container.dataset.msgHelp ||
+      'Select categories to restrict this permission. Leave empty for unrestricted access.';
     wrapper.appendChild(helpText);
 
     container.appendChild(wrapper);

--- a/phpmyfaq/admin/assets/src/group/groups.ts
+++ b/phpmyfaq/admin/assets/src/group/groups.ts
@@ -15,9 +15,18 @@
  * @since     2023-01-04
  */
 
-import { fetchAllGroups, fetchAllMembers, fetchAllUsersForGroups, fetchGroup, fetchGroupRights } from '../api';
+import {
+  fetchAllGroups,
+  fetchAllMembers,
+  fetchAllUsersForGroups,
+  fetchCategoriesForRestrictions,
+  fetchGroup,
+  fetchGroupCategoryRestrictions,
+  fetchGroupRights,
+  saveGroupCategoryRestrictions,
+} from '../api';
 import { selectAll, unSelectAll } from '../utils';
-import { Group, Member, User } from '../interfaces';
+import { CategoryItem, CategoryRestrictions, Group, Member, User } from '../interfaces';
 
 export const handleGroups = async (): Promise<void> => {
   clearGroupList();
@@ -74,6 +83,26 @@ export const handleGroups = async (): Promise<void> => {
   unSelectAllMembers.addEventListener('click', (): void => {
     unSelectAll('group_member_list');
   });
+
+  // Category restrictions save button
+  const saveCategoryRestrictions = document.getElementById('saveCategoryRestrictions') as HTMLButtonElement;
+  if (saveCategoryRestrictions) {
+    saveCategoryRestrictions.addEventListener('click', async (event: Event): Promise<void> => {
+      event.preventDefault();
+      await handleCategoryRestrictionsSave();
+    });
+  }
+
+  // Update category restrictions panel when rights checkboxes change
+  document.getElementById('groupRights')?.addEventListener('change', (event: Event): void => {
+    const target = event.target as HTMLInputElement;
+    if (target.type === 'checkbox' && target.classList.contains('permission')) {
+      const container = document.getElementById('categoryRestrictionsBody');
+      if (container) {
+        renderCategoryRestrictions(container);
+      }
+    }
+  });
 };
 
 const handleGroupSelect = async (event: Event): Promise<void> => {
@@ -88,6 +117,7 @@ const handleGroupSelect = async (event: Event): Promise<void> => {
     await getUserList();
     clearMemberList();
     await getMemberList(groupId);
+    await loadCategoryRestrictions(groupId);
 
     // Activate user inputs
     const saveGroupDetails = document.getElementById('saveGroupDetails') as HTMLButtonElement;
@@ -96,6 +126,7 @@ const handleGroupSelect = async (event: Event): Promise<void> => {
     const deleteGroup = document.getElementById('deleteGroup') as HTMLButtonElement;
     const groupAddMember = document.getElementById('groupAddMember') as HTMLButtonElement;
     const groupRemoveMember = document.getElementById('groupRemoveMember') as HTMLButtonElement;
+    const saveCategoryRestrictions = document.getElementById('saveCategoryRestrictions') as HTMLButtonElement;
 
     saveGroupDetails.disabled = false;
     saveMembersList.disabled = false;
@@ -103,6 +134,9 @@ const handleGroupSelect = async (event: Event): Promise<void> => {
     deleteGroup.disabled = false;
     groupAddMember.disabled = false;
     groupRemoveMember.disabled = false;
+    if (saveCategoryRestrictions) {
+      saveCategoryRestrictions.disabled = false;
+    }
 
     document.querySelectorAll<HTMLInputElement>('.permission').forEach((item: HTMLInputElement): void => {
       item.disabled = false;
@@ -277,5 +311,103 @@ const removeGroupMembers = (): void => {
     if (selectedMembers.includes(member.value)) {
       member.remove();
     }
+  }
+};
+
+let cachedCategories: CategoryItem[] = [];
+let currentRestrictions: CategoryRestrictions = {};
+
+const loadCategoryRestrictions = async (groupId: string): Promise<void> => {
+  const container = document.getElementById('categoryRestrictionsBody');
+  if (!container) {
+    return;
+  }
+
+  if (cachedCategories.length === 0) {
+    cachedCategories = await fetchCategoriesForRestrictions();
+  }
+
+  currentRestrictions = await fetchGroupCategoryRestrictions(groupId);
+
+  renderCategoryRestrictions(container);
+};
+
+const renderCategoryRestrictions = (container: HTMLElement): void => {
+  const checkedRights = document.querySelectorAll<HTMLInputElement>('#groupRights input[type=checkbox]:checked');
+
+  container.innerHTML = '';
+
+  if (checkedRights.length === 0) {
+    container.innerHTML = '<p class="text-muted">No permissions assigned to this group.</p>';
+    return;
+  }
+
+  checkedRights.forEach((checkbox: HTMLInputElement): void => {
+    const rightId = checkbox.value;
+    const label = checkbox.closest('.form-check')?.querySelector('label')?.textContent?.trim() || `Right ${rightId}`;
+    const restrictedCategoryIds = currentRestrictions[rightId] || [];
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'mb-3';
+
+    const labelElement = document.createElement('label');
+    labelElement.className = 'form-label fw-semibold';
+    labelElement.textContent = label;
+    wrapper.appendChild(labelElement);
+
+    const select = document.createElement('select');
+    select.className = 'form-select form-select-sm';
+    select.multiple = true;
+    select.size = 4;
+    select.dataset.rightId = rightId;
+
+    cachedCategories.forEach((cat: CategoryItem): void => {
+      const option = document.createElement('option');
+      option.value = String(cat.id);
+      option.textContent = cat.name;
+      option.selected = restrictedCategoryIds.includes(cat.id);
+      select.appendChild(option);
+    });
+
+    wrapper.appendChild(select);
+
+    const helpText = document.createElement('div');
+    helpText.className = 'form-text';
+    helpText.textContent = 'Select categories to restrict this permission. Leave empty for unrestricted access.';
+    wrapper.appendChild(helpText);
+
+    container.appendChild(wrapper);
+  });
+};
+
+export const handleCategoryRestrictionsSave = async (): Promise<void> => {
+  const groupListSelect = document.getElementById('group_list_select') as HTMLSelectElement;
+  if (!groupListSelect) {
+    return;
+  }
+
+  const groupId = groupListSelect.value;
+  if (!groupId) {
+    return;
+  }
+
+  const container = document.getElementById('categoryRestrictionsBody');
+  if (!container) {
+    return;
+  }
+
+  const selects = container.querySelectorAll<HTMLSelectElement>('select[data-right-id]');
+
+  for (const select of selects) {
+    const rightId = select.dataset.rightId;
+    if (!rightId) {
+      continue;
+    }
+
+    const selectedCategoryIds = [...select.options]
+      .filter((option: HTMLOptionElement): boolean => option.selected)
+      .map((option: HTMLOptionElement): number => parseInt(option.value));
+
+    await saveGroupCategoryRestrictions(groupId, rightId, selectedCategoryIds);
   }
 };

--- a/phpmyfaq/admin/assets/src/group/groups.ts
+++ b/phpmyfaq/admin/assets/src/group/groups.ts
@@ -99,6 +99,7 @@ export const handleGroups = async (): Promise<void> => {
     if (target.type === 'checkbox' && target.classList.contains('permission')) {
       const container = document.getElementById('categoryRestrictionsBody');
       if (container) {
+        captureCurrentRestrictions(container);
         renderCategoryRestrictions(container);
       }
     }
@@ -117,7 +118,11 @@ const handleGroupSelect = async (event: Event): Promise<void> => {
     await getUserList();
     clearMemberList();
     await getMemberList(groupId);
-    await loadCategoryRestrictions(groupId);
+    try {
+      await loadCategoryRestrictions(groupId);
+    } catch (error) {
+      console.error('Failed to load category restrictions:', error);
+    }
 
     // Activate user inputs
     const saveGroupDetails = document.getElementById('saveGroupDetails') as HTMLButtonElement;
@@ -332,6 +337,19 @@ const loadCategoryRestrictions = async (groupId: string): Promise<void> => {
   renderCategoryRestrictions(container);
 };
 
+const captureCurrentRestrictions = (container: HTMLElement): void => {
+  const selects = container.querySelectorAll<HTMLSelectElement>('select[data-right-id]');
+  selects.forEach((select: HTMLSelectElement): void => {
+    const rightId = select.dataset.rightId;
+    if (!rightId) {
+      return;
+    }
+    currentRestrictions[rightId] = [...select.options]
+      .filter((option: HTMLOptionElement): boolean => option.selected)
+      .map((option: HTMLOptionElement): number => parseInt(option.value));
+  });
+};
+
 const renderCategoryRestrictions = (container: HTMLElement): void => {
   const checkedRights = document.querySelectorAll<HTMLInputElement>('#groupRights input[type=checkbox]:checked');
 
@@ -339,7 +357,10 @@ const renderCategoryRestrictions = (container: HTMLElement): void => {
 
   if (checkedRights.length === 0) {
     const emptyMsg = container.dataset.msgEmpty || 'No permissions assigned to this group.';
-    container.innerHTML = `<p class="text-muted">${emptyMsg}</p>`;
+    const emptyParagraph = document.createElement('p');
+    emptyParagraph.className = 'text-muted';
+    emptyParagraph.textContent = emptyMsg;
+    container.appendChild(emptyParagraph);
     return;
   }
 
@@ -400,17 +421,25 @@ export const handleCategoryRestrictionsSave = async (): Promise<void> => {
   }
 
   const csrfToken = container.dataset.csrfToken || '';
-  const selects = container.querySelectorAll<HTMLSelectElement>('select[data-right-id]');
 
-  for (const select of selects) {
-    const rightId = select.dataset.rightId;
-    if (!rightId) {
-      continue;
-    }
+  // Collect every right ID from the permission checkboxes so unticked
+  // permissions also get their stored restrictions cleared.
+  const rightIds = new Set<string>();
+  document
+    .querySelectorAll<HTMLInputElement>('#groupRights input[type=checkbox].permission')
+    .forEach((checkbox: HTMLInputElement): void => {
+      if (checkbox.value) {
+        rightIds.add(checkbox.value);
+      }
+    });
 
-    const selectedCategoryIds = [...select.options]
-      .filter((option: HTMLOptionElement): boolean => option.selected)
-      .map((option: HTMLOptionElement): number => parseInt(option.value));
+  for (const rightId of rightIds) {
+    const select = container.querySelector<HTMLSelectElement>(`select[data-right-id="${rightId}"]`);
+    const selectedCategoryIds = select
+      ? [...select.options]
+          .filter((option: HTMLOptionElement): boolean => option.selected)
+          .map((option: HTMLOptionElement): number => parseInt(option.value))
+      : [];
 
     await saveGroupCategoryRestrictions(groupId, rightId, selectedCategoryIds, csrfToken);
   }

--- a/phpmyfaq/admin/assets/src/interfaces/Group.ts
+++ b/phpmyfaq/admin/assets/src/interfaces/Group.ts
@@ -4,3 +4,13 @@ export interface Group {
   description?: string;
   auto_join?: string;
 }
+
+export interface CategoryItem {
+  id: number;
+  name: string;
+  parent_id: number;
+}
+
+export interface CategoryRestrictions {
+  [rightId: string]: number[];
+}

--- a/phpmyfaq/assets/templates/admin/user/group.twig
+++ b/phpmyfaq/assets/templates/admin/user/group.twig
@@ -212,7 +212,9 @@
         <h5 class="card-header py-3">
           <i aria-hidden="true" class="bi bi-folder-check"></i> {{ 'ad_group_category_restrictions' | translate }}
         </h5>
-        <div class="card-body" id="categoryRestrictionsBody">
+        <div class="card-body" id="categoryRestrictionsBody"
+             data-msg-empty="{{ 'ad_group_no_permissions' | translate }}"
+             data-msg-help="{{ 'ad_group_category_restrictions_select' | translate }}">
           <p class="text-muted">{{ 'ad_group_category_restrictions_help' | translate }}</p>
         </div>
         <div class="card-footer">

--- a/phpmyfaq/assets/templates/admin/user/group.twig
+++ b/phpmyfaq/assets/templates/admin/user/group.twig
@@ -207,6 +207,22 @@
           </div>
         </form>
       </div>
+
+      <div id="groupCategoryRestrictions" class="card shadow mb-4">
+        <h5 class="card-header py-3">
+          <i aria-hidden="true" class="bi bi-folder-check"></i> {{ 'ad_group_category_restrictions' | translate }}
+        </h5>
+        <div class="card-body" id="categoryRestrictionsBody">
+          <p class="text-muted">{{ 'ad_group_category_restrictions_help' | translate }}</p>
+        </div>
+        <div class="card-footer">
+          <div class="card-button text-end">
+            <button id="saveCategoryRestrictions" class="btn btn-primary" type="button" disabled>
+              {{ 'ad_gen_save' | translate }}
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/phpmyfaq/assets/templates/admin/user/group.twig
+++ b/phpmyfaq/assets/templates/admin/user/group.twig
@@ -214,7 +214,8 @@
         </h5>
         <div class="card-body" id="categoryRestrictionsBody"
              data-msg-empty="{{ 'ad_group_no_permissions' | translate }}"
-             data-msg-help="{{ 'ad_group_category_restrictions_select' | translate }}">
+             data-msg-help="{{ 'ad_group_category_restrictions_select' | translate }}"
+             data-csrf-token="{{ csrfTokenCategoryRestrictions }}">
           <p class="text-muted">{{ 'ad_group_category_restrictions_help' | translate }}</p>
         </div>
         <div class="card-footer">

--- a/phpmyfaq/src/phpMyFAQ/Controller/Administration/Api/GroupController.php
+++ b/phpmyfaq/src/phpMyFAQ/Controller/Administration/Api/GroupController.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace phpMyFAQ\Controller\Administration\Api;
 
+use phpMyFAQ\Administration\Category;
 use phpMyFAQ\Core\Exception;
 use phpMyFAQ\Permission\MediumPermission;
 use phpMyFAQ\User\CurrentUser;
@@ -129,5 +130,81 @@ final class GroupController extends AbstractAdministrationApiController
         $groupId = (int) $request->attributes->get('groupId');
 
         return $this->json($currentUser->perm->getGroupRights($groupId), Response::HTTP_OK);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Route(path: 'group/category-restrictions', name: 'admin.api.group.category-restrictions', methods: ['GET'])]
+    public function listCategoryRestrictions(Request $request): JsonResponse
+    {
+        $this->userHasGroupPermission();
+
+        $currentUser = CurrentUser::getCurrentUser($this->configuration);
+
+        $groupId = (int) $request->attributes->get('groupId');
+
+        if (!$currentUser->perm instanceof MediumPermission) {
+            return $this->json([], Response::HTTP_OK);
+        }
+
+        return $this->json($currentUser->perm->getAllCategoryRestrictions($groupId), Response::HTTP_OK);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Route(path: 'group/category-restrictions', name: 'admin.api.group.category-restrictions.save', methods: ['POST'])]
+    public function saveCategoryRestrictions(Request $request): JsonResponse
+    {
+        $this->userHasGroupPermission();
+
+        $currentUser = CurrentUser::getCurrentUser($this->configuration);
+
+        if (!$currentUser->perm instanceof MediumPermission) {
+            return $this->json(['error' => 'Group permissions are not enabled.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        $groupId = (int) ($data['groupId'] ?? 0);
+        $rightId = (int) ($data['rightId'] ?? 0);
+        $categoryIds = array_map('intval', $data['categoryIds'] ?? []);
+
+        if ($groupId <= 0 || $rightId <= 0) {
+            return $this->json(['error' => 'Invalid group or right ID.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $success = $currentUser->perm->setCategoryRestrictions($groupId, $rightId, $categoryIds);
+
+        if (!$success) {
+            return $this->json([
+                'error' => 'Failed to save category restrictions.',
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        return $this->json(['success' => true], Response::HTTP_OK);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Route(path: 'group/categories', name: 'admin.api.group.categories', methods: ['GET'])]
+    public function listCategories(): JsonResponse
+    {
+        $this->userHasGroupPermission();
+
+        $category = new Category($this->configuration);
+        $allCategories = $category->loadCategories();
+
+        $categories = [];
+        foreach ($allCategories as $cat) {
+            $categories[] = [
+                'id' => $cat['id'],
+                'name' => $cat['name'],
+                'parent_id' => $cat['parent_id'],
+            ];
+        }
+
+        return $this->json($categories, Response::HTTP_OK);
     }
 }

--- a/phpmyfaq/src/phpMyFAQ/Controller/Administration/Api/GroupController.php
+++ b/phpmyfaq/src/phpMyFAQ/Controller/Administration/Api/GroupController.php
@@ -136,7 +136,11 @@ final class GroupController extends AbstractAdministrationApiController
     /**
      * @throws Exception
      */
-    #[Route(path: 'group/category-restrictions', name: 'admin.api.group.category-restrictions', methods: ['GET'])]
+    #[Route(
+        path: 'group/category-restrictions/{groupId}',
+        name: 'admin.api.group.category-restrictions',
+        methods: ['GET'],
+    )]
     public function listCategoryRestrictions(Request $request): JsonResponse
     {
         $this->userHasGroupPermission();

--- a/phpmyfaq/src/phpMyFAQ/Controller/Administration/Api/GroupController.php
+++ b/phpmyfaq/src/phpMyFAQ/Controller/Administration/Api/GroupController.php
@@ -145,10 +145,13 @@ final class GroupController extends AbstractAdministrationApiController
         $groupId = (int) $request->attributes->get('groupId');
 
         if (!$currentUser->perm instanceof MediumPermission) {
-            return $this->json([], Response::HTTP_OK);
+            return $this->json(new \stdClass(), Response::HTTP_OK);
         }
 
-        return $this->json($currentUser->perm->getAllCategoryRestrictions($groupId), Response::HTTP_OK);
+        return $this->json(
+            $currentUser->perm->getAllCategoryRestrictions($groupId) ?: new \stdClass(),
+            Response::HTTP_OK,
+        );
     }
 
     /**

--- a/phpmyfaq/src/phpMyFAQ/Controller/Administration/Api/GroupController.php
+++ b/phpmyfaq/src/phpMyFAQ/Controller/Administration/Api/GroupController.php
@@ -22,6 +22,7 @@ namespace phpMyFAQ\Controller\Administration\Api;
 use phpMyFAQ\Administration\Category;
 use phpMyFAQ\Core\Exception;
 use phpMyFAQ\Permission\MediumPermission;
+use phpMyFAQ\Session\Token;
 use phpMyFAQ\User\CurrentUser;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -171,6 +172,10 @@ final class GroupController extends AbstractAdministrationApiController
         $data = json_decode($request->getContent(), true);
         if (!is_array($data)) {
             return $this->json(['error' => 'Invalid JSON payload.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        if (!Token::getInstance($this->session)->verifyToken('save-category-restrictions', $data['csrfToken'] ?? '')) {
+            return $this->json(['error' => 'Invalid CSRF token.'], Response::HTTP_FORBIDDEN);
         }
 
         $groupId = (int) ($data['groupId'] ?? 0);

--- a/phpmyfaq/src/phpMyFAQ/Controller/Administration/Api/GroupController.php
+++ b/phpmyfaq/src/phpMyFAQ/Controller/Administration/Api/GroupController.php
@@ -166,13 +166,26 @@ final class GroupController extends AbstractAdministrationApiController
         }
 
         $data = json_decode($request->getContent(), true);
+        if (!is_array($data)) {
+            return $this->json(['error' => 'Invalid JSON payload.'], Response::HTTP_BAD_REQUEST);
+        }
+
         $groupId = (int) ($data['groupId'] ?? 0);
         $rightId = (int) ($data['rightId'] ?? 0);
-        $categoryIds = array_map('intval', $data['categoryIds'] ?? []);
 
         if ($groupId <= 0 || $rightId <= 0) {
             return $this->json(['error' => 'Invalid group or right ID.'], Response::HTTP_BAD_REQUEST);
         }
+
+        $rawCategoryIds = $data['categoryIds'] ?? [];
+        if (!is_array($rawCategoryIds)) {
+            return $this->json(['error' => 'categoryIds must be an array.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $categoryIds = array_values(array_filter(
+            array_map('intval', $rawCategoryIds),
+            static fn(int $id): bool => $id > 0,
+        ));
 
         $success = $currentUser->perm->setCategoryRestrictions($groupId, $rightId, $categoryIds);
 

--- a/phpmyfaq/src/phpMyFAQ/Controller/Administration/GroupController.php
+++ b/phpmyfaq/src/phpMyFAQ/Controller/Administration/GroupController.php
@@ -361,6 +361,9 @@ final class GroupController extends AbstractAdministrationController
             'csrfTokenUpdateGroupPermissions' => Token::getInstance($this->session)->getTokenString(
                 'update-group-permissions',
             ),
+            'csrfTokenCategoryRestrictions' => Token::getInstance($this->session)->getTokenString(
+                'save-category-restrictions',
+            ),
         ];
     }
 }

--- a/phpmyfaq/src/phpMyFAQ/Permission/GroupCategoryPermissionRepository.php
+++ b/phpmyfaq/src/phpMyFAQ/Permission/GroupCategoryPermissionRepository.php
@@ -1,0 +1,247 @@
+<?php
+
+/**
+ * Repository for group-level category permission restrictions.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * @package   phpMyFAQ
+ * @author    Thorsten Rinne <thorsten@phpmyfaq.de>
+ * @copyright 2026 phpMyFAQ Team
+ * @license   https://www.mozilla.org/MPL/2.0/ Mozilla Public License Version 2.0
+ * @link      https://www.phpmyfaq.de
+ * @since     2026-03-15
+ */
+
+declare(strict_types=1);
+
+namespace phpMyFAQ\Permission;
+
+use phpMyFAQ\Configuration;
+use phpMyFAQ\Database;
+
+readonly class GroupCategoryPermissionRepository
+{
+    public function __construct(
+        private Configuration $configuration,
+    ) {
+    }
+
+    /**
+     * Returns the category IDs that a group's right is restricted to.
+     * An empty array means the right is unrestricted (applies globally).
+     *
+     * @param int $groupId Group ID
+     * @param int $rightId Right ID
+     * @return array<int>
+     */
+    public function getCategoryRestrictions(int $groupId, int $rightId): array
+    {
+        if ($groupId <= 0 || $rightId <= 0) {
+            return [];
+        }
+
+        $select = sprintf(
+            'SELECT category_id FROM %sfaqgroup_right_category WHERE group_id = %d AND right_id = %d',
+            Database::getTablePrefix(),
+            $groupId,
+            $rightId,
+        );
+
+        $res = $this->configuration->getDb()->query($select);
+        if (!$res) {
+            return [];
+        }
+
+        $result = [];
+        while (true) {
+            $row = $this->configuration->getDb()->fetchArray($res);
+            if ($row === false || $row === null || $row === []) {
+                break;
+            }
+
+            $result[] = (int) $row['category_id'];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns all category restrictions for a group, keyed by right ID.
+     *
+     * @param int $groupId Group ID
+     * @return array<int, array<int>> Map of right_id => [category_ids]
+     */
+    public function getAllCategoryRestrictions(int $groupId): array
+    {
+        if ($groupId <= 0) {
+            return [];
+        }
+
+        $select = sprintf(
+            'SELECT right_id, category_id FROM %sfaqgroup_right_category WHERE group_id = %d ORDER BY right_id',
+            Database::getTablePrefix(),
+            $groupId,
+        );
+
+        $res = $this->configuration->getDb()->query($select);
+        if (!$res) {
+            return [];
+        }
+
+        $result = [];
+        while (true) {
+            $row = $this->configuration->getDb()->fetchArray($res);
+            if ($row === false || $row === null || $row === []) {
+                break;
+            }
+
+            $rightId = (int) $row['right_id'];
+            $result[$rightId][] = (int) $row['category_id'];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Sets category restrictions for a group's right.
+     * Replaces any existing restrictions for this group-right pair.
+     *
+     * @param int $groupId Group ID
+     * @param int $rightId Right ID
+     * @param array<int> $categoryIds Category IDs to restrict to
+     */
+    public function setCategoryRestrictions(int $groupId, int $rightId, array $categoryIds): bool
+    {
+        if ($groupId <= 0 || $rightId <= 0) {
+            return false;
+        }
+
+        // Remove existing restrictions
+        if (!$this->deleteCategoryRestrictions($groupId, $rightId)) {
+            return false;
+        }
+
+        // Insert new restrictions
+        foreach ($categoryIds as $categoryId) {
+            $categoryId = (int) $categoryId;
+            if ($categoryId <= 0) {
+                continue;
+            }
+
+            $insert = sprintf(
+                'INSERT INTO %sfaqgroup_right_category (group_id, right_id, category_id) VALUES (%d, %d, %d)',
+                Database::getTablePrefix(),
+                $groupId,
+                $rightId,
+                $categoryId,
+            );
+
+            if (!$this->configuration->getDb()->query($insert)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Deletes all category restrictions for a specific group-right pair.
+     *
+     * @param int $groupId Group ID
+     * @param int $rightId Right ID
+     */
+    public function deleteCategoryRestrictions(int $groupId, int $rightId): bool
+    {
+        if ($groupId <= 0 || $rightId <= 0) {
+            return false;
+        }
+
+        $delete = sprintf(
+            'DELETE FROM %sfaqgroup_right_category WHERE group_id = %d AND right_id = %d',
+            Database::getTablePrefix(),
+            $groupId,
+            $rightId,
+        );
+
+        return (bool) $this->configuration->getDb()->query($delete);
+    }
+
+    /**
+     * Deletes all category restrictions for a group.
+     *
+     * @param int $groupId Group ID
+     */
+    public function deleteAllForGroup(int $groupId): bool
+    {
+        if ($groupId <= 0) {
+            return false;
+        }
+
+        $delete = sprintf(
+            'DELETE FROM %sfaqgroup_right_category WHERE group_id = %d',
+            Database::getTablePrefix(),
+            $groupId,
+        );
+
+        return (bool) $this->configuration->getDb()->query($delete);
+    }
+
+    /**
+     * Checks if a user has a specific right for a given category via group membership.
+     * Returns true if:
+     * - The user's group has the right with no category restrictions (global), OR
+     * - The user's group has the right restricted to categories that include the given category.
+     *
+     * @param int $userId User ID
+     * @param int $rightId Right ID
+     * @param int $categoryId Category ID
+     */
+    public function checkUserGroupRightForCategory(int $userId, int $rightId, int $categoryId): bool
+    {
+        if ($userId <= 0 || $rightId <= 0 || $categoryId <= 0) {
+            return false;
+        }
+
+        // Check if user has the right via any group that either:
+        // 1. Has no category restrictions for this right (global), OR
+        // 2. Has the specific category in its restrictions
+        $select = sprintf(
+            '
+            SELECT
+                fgr.group_id
+            FROM
+                %sfaqgroup_right fgr
+            INNER JOIN
+                %sfaquser_group fug ON fgr.group_id = fug.group_id
+            WHERE
+                fug.user_id = %d AND
+                fgr.right_id = %d AND
+                (
+                    NOT EXISTS (
+                        SELECT 1 FROM %sfaqgroup_right_category fgrc
+                        WHERE fgrc.group_id = fgr.group_id AND fgrc.right_id = fgr.right_id
+                    )
+                    OR EXISTS (
+                        SELECT 1 FROM %sfaqgroup_right_category fgrc
+                        WHERE fgrc.group_id = fgr.group_id
+                          AND fgrc.right_id = fgr.right_id
+                          AND fgrc.category_id = %d
+                    )
+                )',
+            Database::getTablePrefix(),
+            Database::getTablePrefix(),
+            $userId,
+            $rightId,
+            Database::getTablePrefix(),
+            Database::getTablePrefix(),
+            $categoryId,
+        );
+
+        $res = $this->configuration->getDb()->query($select);
+
+        return $this->configuration->getDb()->numRows($res) > 0;
+    }
+}

--- a/phpmyfaq/src/phpMyFAQ/Permission/GroupCategoryPermissionRepository.php
+++ b/phpmyfaq/src/phpMyFAQ/Permission/GroupCategoryPermissionRepository.php
@@ -119,8 +119,20 @@ readonly class GroupCategoryPermissionRepository
             return false;
         }
 
+        $db = $this->configuration->getDb();
+
+        $db->query('BEGIN');
+
         // Remove existing restrictions
-        if (!$this->deleteCategoryRestrictions($groupId, $rightId)) {
+        $delete = sprintf(
+            'DELETE FROM %sfaqgroup_right_category WHERE group_id = %d AND right_id = %d',
+            Database::getTablePrefix(),
+            $groupId,
+            $rightId,
+        );
+
+        if (!$db->query($delete)) {
+            $db->query('ROLLBACK');
             return false;
         }
 
@@ -139,10 +151,13 @@ readonly class GroupCategoryPermissionRepository
                 $categoryId,
             );
 
-            if (!$this->configuration->getDb()->query($insert)) {
+            if (!$db->query($insert)) {
+                $db->query('ROLLBACK');
                 return false;
             }
         }
+
+        $db->query('COMMIT');
 
         return true;
     }

--- a/phpmyfaq/src/phpMyFAQ/Permission/MediumPermission.php
+++ b/phpmyfaq/src/phpMyFAQ/Permission/MediumPermission.php
@@ -33,11 +33,14 @@ class MediumPermission extends BasicPermission implements PermissionInterface
 {
     protected MediumPermissionRepository $mediumRepository;
 
+    protected GroupCategoryPermissionRepository $categoryPermissionRepository;
+
     public function __construct(
         protected Configuration $configuration,
     ) {
         parent::__construct($configuration);
         $this->mediumRepository = new MediumPermissionRepository($configuration);
+        $this->categoryPermissionRepository = new GroupCategoryPermissionRepository($configuration);
     }
 
     /**
@@ -221,6 +224,8 @@ class MediumPermission extends BasicPermission implements PermissionInterface
         if (!$this->mediumRepository->deleteGroupMemberships($groupId)) {
             return false;
         }
+
+        $this->categoryPermissionRepository->deleteAllForGroup($groupId);
 
         return $this->mediumRepository->deleteGroupRights($groupId);
     }
@@ -486,5 +491,81 @@ class MediumPermission extends BasicPermission implements PermissionInterface
         ];
 
         return $this->addGroup($groupData);
+    }
+
+    /**
+     * Returns true if the user has the specified right for the given category,
+     * taking into account group-level category restrictions.
+     *
+     * If the user's group has no category restrictions for a right, the right
+     * applies globally. If restrictions exist, the right only applies to
+     * the specified categories.
+     *
+     * @param int   $userId     User ID
+     * @param mixed $right      Right ID, name, or PermissionType enum
+     * @param int   $categoryId Category ID
+     * @throws Exception
+     */
+    public function hasPermissionForCategory(int $userId, mixed $right, int $categoryId): bool
+    {
+        $currentUser = new CurrentUser($this->configuration);
+        $currentUser->getUserById($userId);
+
+        if ($currentUser->isSuperAdmin()) {
+            return true;
+        }
+
+        // Resolve right to ID
+        if (!is_numeric($right) && is_string($right)) {
+            $right = $this->getRightId($right);
+        }
+
+        if ($right instanceof PermissionType) {
+            $right = $this->getRightId($right->value);
+        }
+
+        // Check direct user right (always global, no category restriction)
+        if ($this->checkUserRight($userId, $right)) {
+            return true;
+        }
+
+        // Check group right with category restrictions
+        return $this->categoryPermissionRepository->checkUserGroupRightForCategory($userId, $right, $categoryId);
+    }
+
+    /**
+     * Returns the category IDs that a group's right is restricted to.
+     * An empty array means the right is unrestricted (applies globally).
+     *
+     * @param int $groupId Group ID
+     * @param int $rightId Right ID
+     * @return array<int>
+     */
+    public function getCategoryRestrictions(int $groupId, int $rightId): array
+    {
+        return $this->categoryPermissionRepository->getCategoryRestrictions($groupId, $rightId);
+    }
+
+    /**
+     * Returns all category restrictions for a group, keyed by right ID.
+     *
+     * @param int $groupId Group ID
+     * @return array<int, array<int>> Map of right_id => [category_ids]
+     */
+    public function getAllCategoryRestrictions(int $groupId): array
+    {
+        return $this->categoryPermissionRepository->getAllCategoryRestrictions($groupId);
+    }
+
+    /**
+     * Sets category restrictions for a group's right.
+     *
+     * @param int $groupId Group ID
+     * @param int $rightId Right ID
+     * @param array<int> $categoryIds Category IDs to restrict to (empty = unrestricted)
+     */
+    public function setCategoryRestrictions(int $groupId, int $rightId, array $categoryIds): bool
+    {
+        return $this->categoryPermissionRepository->setCategoryRestrictions($groupId, $rightId, $categoryIds);
     }
 }

--- a/phpmyfaq/src/phpMyFAQ/Permission/MediumPermission.php
+++ b/phpmyfaq/src/phpMyFAQ/Permission/MediumPermission.php
@@ -504,12 +504,19 @@ class MediumPermission extends BasicPermission implements PermissionInterface
      * @param int   $userId     User ID
      * @param mixed $right      Right ID, name, or PermissionType enum
      * @param int   $categoryId Category ID
+     * @param CurrentUser|null $currentUser Optional pre-loaded user to avoid repeated instantiation
      * @throws Exception
      */
-    public function hasPermissionForCategory(int $userId, mixed $right, int $categoryId): bool
-    {
-        $currentUser = new CurrentUser($this->configuration);
-        $currentUser->getUserById($userId);
+    public function hasPermissionForCategory(
+        int $userId,
+        mixed $right,
+        int $categoryId,
+        ?CurrentUser $currentUser = null,
+    ): bool {
+        if ($currentUser === null) {
+            $currentUser = new CurrentUser($this->configuration);
+            $currentUser->getUserById($userId);
+        }
 
         if ($currentUser->isSuperAdmin()) {
             return true;

--- a/phpmyfaq/src/phpMyFAQ/Setup/Installation/DatabaseSchema.php
+++ b/phpmyfaq/src/phpMyFAQ/Setup/Installation/DatabaseSchema.php
@@ -64,6 +64,7 @@ class DatabaseSchema
             'faqglossary' => $this->faqglossary(),
             'faqgroup' => $this->faqgroup(),
             'faqgroup_right' => $this->faqgroupRight(),
+            'faqgroup_right_category' => $this->faqgroupRightCategory(),
             'faqapi_keys' => $this->faqapiKeys(),
             'faqoauth_clients' => $this->faqoauthClients(),
             'faqoauth_scopes' => $this->faqoauthScopes(),
@@ -402,6 +403,16 @@ class DatabaseSchema
             ->integer('group_id', false)
             ->integer('right_id', false)
             ->primaryKey(['group_id', 'right_id']);
+    }
+
+    public function faqgroupRightCategory(): TableBuilder
+    {
+        return new TableBuilder($this->dialect)
+            ->table('faqgroup_right_category')
+            ->integer('group_id', false)
+            ->integer('right_id', false)
+            ->integer('category_id', false)
+            ->primaryKey(['group_id', 'right_id', 'category_id']);
     }
 
     public function faqinstances(): TableBuilder

--- a/phpmyfaq/src/phpMyFAQ/Setup/Migration/MigrationRegistry.php
+++ b/phpmyfaq/src/phpMyFAQ/Setup/Migration/MigrationRegistry.php
@@ -69,6 +69,7 @@ class MigrationRegistry
             '4.1.0-alpha.2' => Versions\Migration410Alpha2::class,
             '4.1.0-alpha.3' => Versions\Migration410Alpha3::class,
             '4.2.0-alpha' => Versions\Migration420Alpha::class,
+            '4.2.0-alpha.2' => Versions\Migration420Alpha2::class,
         ];
     }
 

--- a/phpmyfaq/src/phpMyFAQ/Setup/Migration/Versions/Migration420Alpha2.php
+++ b/phpmyfaq/src/phpMyFAQ/Setup/Migration/Versions/Migration420Alpha2.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Migration for phpMyFAQ 4.2.0-alpha.2.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * @package   phpMyFAQ
+ * @author    Thorsten Rinne <thorsten@phpmyfaq.de>
+ * @copyright 2026 phpMyFAQ Team
+ * @license   https://www.mozilla.org/MPL/2.0/ Mozilla Public License Version 2.0
+ * @link      https://www.phpmyfaq.de
+ * @since     2026-03-15
+ */
+
+declare(strict_types=1);
+
+namespace phpMyFAQ\Setup\Migration\Versions;
+
+use phpMyFAQ\Setup\Migration\AbstractMigration;
+use phpMyFAQ\Setup\Migration\Operations\OperationRecorder;
+
+readonly class Migration420Alpha2 extends AbstractMigration
+{
+    public function getVersion(): string
+    {
+        return '4.2.0-alpha.2';
+    }
+
+    public function getDependencies(): array
+    {
+        return ['4.2.0-alpha'];
+    }
+
+    public function getDescription(): string
+    {
+        return 'Add faqgroup_right_category table for granular group-based category permissions';
+    }
+
+    public function up(OperationRecorder $recorder): void
+    {
+        $intType = $this->integerType();
+
+        if ($this->isMySql()) {
+            $recorder->addSql(
+                sprintf(
+                    'CREATE TABLE IF NOT EXISTS %sfaqgroup_right_category (
+                        group_id %s NOT NULL,
+                        right_id %s NOT NULL,
+                        category_id %s NOT NULL,
+                        PRIMARY KEY (group_id, right_id, category_id)
+                    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci',
+                    $this->tablePrefix,
+                    $intType,
+                    $intType,
+                    $intType,
+                ),
+                'Create faqgroup_right_category table (MySQL)',
+            );
+        }
+
+        if ($this->isPostgreSql()) {
+            $recorder->addSql(
+                sprintf('CREATE TABLE IF NOT EXISTS %sfaqgroup_right_category (
+                        group_id %s NOT NULL,
+                        right_id %s NOT NULL,
+                        category_id %s NOT NULL,
+                        PRIMARY KEY (group_id, right_id, category_id)
+                    )', $this->tablePrefix, $intType, $intType, $intType),
+                'Create faqgroup_right_category table (PostgreSQL)',
+            );
+        }
+
+        if ($this->isSqlite()) {
+            $recorder->addSql(
+                sprintf('CREATE TABLE IF NOT EXISTS %sfaqgroup_right_category (
+                        group_id %s NOT NULL,
+                        right_id %s NOT NULL,
+                        category_id %s NOT NULL,
+                        PRIMARY KEY (group_id, right_id, category_id)
+                    )', $this->tablePrefix, $intType, $intType, $intType),
+                'Create faqgroup_right_category table (SQLite)',
+            );
+        }
+
+        if ($this->isSqlServer()) {
+            $recorder->addSql(
+                sprintf(
+                    'IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = \'%sfaqgroup_right_category\') '
+                    . 'CREATE TABLE %sfaqgroup_right_category (
+                        group_id %s NOT NULL,
+                        right_id %s NOT NULL,
+                        category_id %s NOT NULL,
+                        PRIMARY KEY (group_id, right_id, category_id)
+                    )',
+                    $this->tablePrefix,
+                    $this->tablePrefix,
+                    $intType,
+                    $intType,
+                    $intType,
+                ),
+                'Create faqgroup_right_category table (SQL Server)',
+            );
+        }
+    }
+
+    public function isReversible(): bool
+    {
+        return true;
+    }
+
+    public function down(OperationRecorder $recorder): void
+    {
+        $recorder->addSql($this->dropTableIfExists('faqgroup_right_category'), 'Drop faqgroup_right_category table');
+    }
+}

--- a/phpmyfaq/translations/language_en.php
+++ b/phpmyfaq/translations/language_en.php
@@ -1783,4 +1783,7 @@ $PMF_LANG['ad_layout_mode_highContrast'] = 'High contrast';
 
 $PMF_LANG['msgThemeUploadNoZip'] = 'Please select a ZIP file to upload.';
 
+$PMF_LANG['ad_group_category_restrictions'] = 'Category Restrictions';
+$PMF_LANG['ad_group_category_restrictions_help'] = 'Select a group to manage category restrictions for its permissions.';
+
 return $PMF_LANG;

--- a/phpmyfaq/translations/language_en.php
+++ b/phpmyfaq/translations/language_en.php
@@ -1785,5 +1785,7 @@ $PMF_LANG['msgThemeUploadNoZip'] = 'Please select a ZIP file to upload.';
 
 $PMF_LANG['ad_group_category_restrictions'] = 'Category Restrictions';
 $PMF_LANG['ad_group_category_restrictions_help'] = 'Select a group to manage category restrictions for its permissions.';
+$PMF_LANG['ad_group_no_permissions'] = 'No permissions assigned to this group.';
+$PMF_LANG['ad_group_category_restrictions_select'] = 'Select categories to restrict this permission. Leave empty for unrestricted access.';
 
 return $PMF_LANG;

--- a/tests/phpMyFAQ/Permission/GroupCategoryPermissionRepositoryTest.php
+++ b/tests/phpMyFAQ/Permission/GroupCategoryPermissionRepositoryTest.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace phpMyFAQ\Permission;
+
+use phpMyFAQ\Configuration;
+use phpMyFAQ\Database;
+use phpMyFAQ\Database\Sqlite3;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class GroupCategoryPermissionRepositoryTest extends TestCase
+{
+    private Sqlite3 $dbHandle;
+
+    private Configuration $configuration;
+
+    private GroupCategoryPermissionRepository $repository;
+
+    private string $databasePath;
+
+    private ?Configuration $previousConfiguration = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $configurationReflection = new ReflectionClass(Configuration::class);
+        $configurationProperty = $configurationReflection->getProperty('configuration');
+        $this->previousConfiguration = $configurationProperty->getValue();
+
+        $databasePath = tempnam(sys_get_temp_dir(), 'pmf-group-cat-perm-');
+        self::assertNotFalse($databasePath);
+        self::assertTrue(copy(PMF_TEST_DIR . '/test.db', $databasePath));
+        $this->databasePath = $databasePath;
+
+        $this->dbHandle = new Sqlite3();
+        $this->dbHandle->connect($this->databasePath, '', '');
+        $this->initializeDatabaseStatics($this->dbHandle);
+        $this->configuration = new Configuration($this->dbHandle);
+
+        // Clean up test data
+        $this->dbHandle->query('DELETE FROM faqgroup_right_category');
+        $this->dbHandle->query('DELETE FROM faqgroup_right');
+        $this->dbHandle->query('DELETE FROM faquser_group');
+        $this->dbHandle->query('DELETE FROM faqgroup');
+
+        $this->repository = new GroupCategoryPermissionRepository($this->configuration);
+    }
+
+    protected function tearDown(): void
+    {
+        $configurationReflection = new ReflectionClass(Configuration::class);
+        $configurationProperty = $configurationReflection->getProperty('configuration');
+        $configurationProperty->setValue(null, $this->previousConfiguration);
+
+        if (isset($this->dbHandle)) {
+            $this->dbHandle->close();
+        }
+
+        if (isset($this->databasePath) && is_file($this->databasePath)) {
+            unlink($this->databasePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testGetCategoryRestrictionsReturnsEmptyForInvalidInput(): void
+    {
+        $this->assertEmpty($this->repository->getCategoryRestrictions(0, 1));
+        $this->assertEmpty($this->repository->getCategoryRestrictions(1, 0));
+        $this->assertEmpty($this->repository->getCategoryRestrictions(-1, -1));
+    }
+
+    public function testGetCategoryRestrictionsReturnsEmptyWhenNoRestrictions(): void
+    {
+        $this->assertEmpty($this->repository->getCategoryRestrictions(1, 1));
+    }
+
+    public function testSetAndGetCategoryRestrictions(): void
+    {
+        $this->assertTrue($this->repository->setCategoryRestrictions(1, 1, [10, 20, 30]));
+
+        $restrictions = $this->repository->getCategoryRestrictions(1, 1);
+        $this->assertCount(3, $restrictions);
+        $this->assertContains(10, $restrictions);
+        $this->assertContains(20, $restrictions);
+        $this->assertContains(30, $restrictions);
+    }
+
+    public function testSetCategoryRestrictionsReplacesExisting(): void
+    {
+        $this->assertTrue($this->repository->setCategoryRestrictions(1, 1, [10, 20]));
+        $this->assertCount(2, $this->repository->getCategoryRestrictions(1, 1));
+
+        $this->assertTrue($this->repository->setCategoryRestrictions(1, 1, [30, 40, 50]));
+        $restrictions = $this->repository->getCategoryRestrictions(1, 1);
+        $this->assertCount(3, $restrictions);
+        $this->assertContains(30, $restrictions);
+        $this->assertNotContains(10, $restrictions);
+    }
+
+    public function testSetCategoryRestrictionsWithEmptyArrayClearsRestrictions(): void
+    {
+        $this->assertTrue($this->repository->setCategoryRestrictions(1, 1, [10, 20]));
+        $this->assertCount(2, $this->repository->getCategoryRestrictions(1, 1));
+
+        $this->assertTrue($this->repository->setCategoryRestrictions(1, 1, []));
+        $this->assertEmpty($this->repository->getCategoryRestrictions(1, 1));
+    }
+
+    public function testSetCategoryRestrictionsReturnsFalseForInvalidInput(): void
+    {
+        $this->assertFalse($this->repository->setCategoryRestrictions(0, 1, [10]));
+        $this->assertFalse($this->repository->setCategoryRestrictions(1, 0, [10]));
+    }
+
+    public function testDeleteCategoryRestrictions(): void
+    {
+        $this->repository->setCategoryRestrictions(1, 1, [10, 20]);
+        $this->repository->setCategoryRestrictions(1, 2, [30]);
+
+        $this->assertTrue($this->repository->deleteCategoryRestrictions(1, 1));
+        $this->assertEmpty($this->repository->getCategoryRestrictions(1, 1));
+        $this->assertCount(1, $this->repository->getCategoryRestrictions(1, 2));
+    }
+
+    public function testDeleteCategoryRestrictionsReturnsFalseForInvalidInput(): void
+    {
+        $this->assertFalse($this->repository->deleteCategoryRestrictions(0, 1));
+        $this->assertFalse($this->repository->deleteCategoryRestrictions(1, 0));
+    }
+
+    public function testDeleteAllForGroup(): void
+    {
+        $this->repository->setCategoryRestrictions(1, 1, [10, 20]);
+        $this->repository->setCategoryRestrictions(1, 2, [30]);
+        $this->repository->setCategoryRestrictions(2, 1, [40]);
+
+        $this->assertTrue($this->repository->deleteAllForGroup(1));
+        $this->assertEmpty($this->repository->getCategoryRestrictions(1, 1));
+        $this->assertEmpty($this->repository->getCategoryRestrictions(1, 2));
+        $this->assertCount(1, $this->repository->getCategoryRestrictions(2, 1));
+    }
+
+    public function testDeleteAllForGroupReturnsFalseForInvalidInput(): void
+    {
+        $this->assertFalse($this->repository->deleteAllForGroup(0));
+    }
+
+    public function testGetAllCategoryRestrictions(): void
+    {
+        $this->assertEmpty($this->repository->getAllCategoryRestrictions(0));
+
+        $this->repository->setCategoryRestrictions(1, 1, [10, 20]);
+        $this->repository->setCategoryRestrictions(1, 3, [30]);
+
+        $all = $this->repository->getAllCategoryRestrictions(1);
+        $this->assertCount(2, $all);
+        $this->assertArrayHasKey(1, $all);
+        $this->assertArrayHasKey(3, $all);
+        $this->assertContains(10, $all[1]);
+        $this->assertContains(20, $all[1]);
+        $this->assertContains(30, $all[3]);
+    }
+
+    public function testCheckUserGroupRightForCategoryWithNoRestrictions(): void
+    {
+        // Set up: create group, add user, grant right
+        $this->dbHandle->query("INSERT INTO faqgroup (group_id, name, description, auto_join) VALUES (1, 'TestGroup', 'Test', 0)");
+        $this->dbHandle->query('INSERT INTO faquser_group (user_id, group_id) VALUES (1, 1)');
+        $this->dbHandle->query('INSERT INTO faqgroup_right (group_id, right_id) VALUES (1, 1)');
+
+        // No category restrictions -> should have access to any category
+        $this->assertTrue($this->repository->checkUserGroupRightForCategory(1, 1, 99));
+    }
+
+    public function testCheckUserGroupRightForCategoryWithMatchingRestriction(): void
+    {
+        $this->dbHandle->query("INSERT INTO faqgroup (group_id, name, description, auto_join) VALUES (1, 'TestGroup', 'Test', 0)");
+        $this->dbHandle->query('INSERT INTO faquser_group (user_id, group_id) VALUES (1, 1)');
+        $this->dbHandle->query('INSERT INTO faqgroup_right (group_id, right_id) VALUES (1, 1)');
+
+        // Restrict right 1 to category 10
+        $this->repository->setCategoryRestrictions(1, 1, [10, 20]);
+
+        // Should have access to category 10
+        $this->assertTrue($this->repository->checkUserGroupRightForCategory(1, 1, 10));
+        // Should have access to category 20
+        $this->assertTrue($this->repository->checkUserGroupRightForCategory(1, 1, 20));
+        // Should NOT have access to category 30
+        $this->assertFalse($this->repository->checkUserGroupRightForCategory(1, 1, 30));
+    }
+
+    public function testCheckUserGroupRightForCategoryReturnsFalseForInvalidInput(): void
+    {
+        $this->assertFalse($this->repository->checkUserGroupRightForCategory(0, 1, 1));
+        $this->assertFalse($this->repository->checkUserGroupRightForCategory(1, 0, 1));
+        $this->assertFalse($this->repository->checkUserGroupRightForCategory(1, 1, 0));
+    }
+
+    public function testCheckUserGroupRightForCategoryWithMultipleGroups(): void
+    {
+        // Group 1: restricted to category 10
+        $this->dbHandle->query("INSERT INTO faqgroup (group_id, name, description, auto_join) VALUES (1, 'Group1', 'Test', 0)");
+        $this->dbHandle->query('INSERT INTO faqgroup_right (group_id, right_id) VALUES (1, 1)');
+        $this->repository->setCategoryRestrictions(1, 1, [10]);
+
+        // Group 2: unrestricted (no category restrictions)
+        $this->dbHandle->query("INSERT INTO faqgroup (group_id, name, description, auto_join) VALUES (2, 'Group2', 'Test', 0)");
+        $this->dbHandle->query('INSERT INTO faqgroup_right (group_id, right_id) VALUES (2, 1)');
+
+        // User in both groups
+        $this->dbHandle->query('INSERT INTO faquser_group (user_id, group_id) VALUES (1, 1)');
+        $this->dbHandle->query('INSERT INTO faquser_group (user_id, group_id) VALUES (1, 2)');
+
+        // User should have access to any category because Group 2 is unrestricted
+        $this->assertTrue($this->repository->checkUserGroupRightForCategory(1, 1, 99));
+    }
+
+    private function initializeDatabaseStatics(Sqlite3 $dbHandle): void
+    {
+        $databaseReflection = new ReflectionClass(Database::class);
+        $databaseDriverProperty = $databaseReflection->getProperty('databaseDriver');
+        $databaseDriverProperty->setValue(null, $dbHandle);
+        $dbTypeProperty = $databaseReflection->getProperty('dbType');
+        $dbTypeProperty->setValue(null, 'sqlite3');
+        Database::setTablePrefix('');
+    }
+}

--- a/tests/phpMyFAQ/Permission/MediumPermissionTest.php
+++ b/tests/phpMyFAQ/Permission/MediumPermissionTest.php
@@ -40,6 +40,7 @@ class MediumPermissionTest extends TestCase
         $this->dbHandle->connect($this->databasePath, '', '');
         $this->initializeDatabaseStatics($this->dbHandle);
         $this->configuration = new Configuration($this->dbHandle);
+        $this->dbHandle->query('DELETE FROM faqgroup_right_category');
         $this->dbHandle->query('DELETE FROM faqgroup_right');
         $this->dbHandle->query('DELETE FROM faquser_group');
         $this->dbHandle->query('DELETE FROM faqgroup');
@@ -509,6 +510,115 @@ class MediumPermissionTest extends TestCase
         // Cleanup
         $this->mediumPermission->deleteGroup($groupId);
         $this->mediumPermission->deleteGroup($groupId2);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testHasPermissionForCategoryWithUnrestrictedGroupRight(): void
+    {
+        $groupData = [
+            'name' => 'TestGroup',
+            'description' => 'TestDescription',
+            'auto_join' => false,
+        ];
+        $this->mediumPermission->addGroup($groupData);
+        $this->mediumPermission->addToGroup(1, 1);
+        $this->mediumPermission->grantGroupRight(1, 1);
+
+        // No category restrictions -> should have access to any category
+        $this->assertTrue($this->mediumPermission->hasPermissionForCategory(1, 1, 99));
+
+        // Cleanup
+        $this->mediumPermission->deleteGroup(1);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testHasPermissionForCategoryWithRestrictedGroupRight(): void
+    {
+        // Make user 1 non-superadmin and remove direct user right so only group right applies
+        $this->configuration->getDb()->query('UPDATE faquser SET is_superadmin = 0 WHERE user_id = 1');
+        $this->configuration->getDb()->query('DELETE FROM faquser_right WHERE user_id = 1 AND right_id = 1');
+
+        $groupData = [
+            'name' => 'TestGroup',
+            'description' => 'TestDescription',
+            'auto_join' => false,
+        ];
+        $this->mediumPermission->addGroup($groupData);
+        $this->mediumPermission->addToGroup(1, 1);
+        $this->mediumPermission->grantGroupRight(1, 1);
+
+        // Restrict right 1 to category 10
+        $this->mediumPermission->setCategoryRestrictions(1, 1, [10]);
+
+        // Should have access to category 10
+        $this->assertTrue($this->mediumPermission->hasPermissionForCategory(1, 1, 10));
+        // Should NOT have access to category 20
+        $this->assertFalse($this->mediumPermission->hasPermissionForCategory(1, 1, 20));
+
+        // Cleanup
+        $this->mediumPermission->deleteGroup(1);
+        $this->configuration->getDb()->query('UPDATE faquser SET is_superadmin = 1 WHERE user_id = 1');
+        $this->configuration->getDb()->query('INSERT INTO faquser_right (user_id, right_id) VALUES (1, 1)');
+    }
+
+    public function testGetAndSetCategoryRestrictions(): void
+    {
+        $groupData = [
+            'name' => 'TestGroup',
+            'description' => 'TestDescription',
+            'auto_join' => false,
+        ];
+        $this->mediumPermission->addGroup($groupData);
+
+        $this->assertEmpty($this->mediumPermission->getCategoryRestrictions(1, 1));
+
+        $this->assertTrue($this->mediumPermission->setCategoryRestrictions(1, 1, [10, 20]));
+        $restrictions = $this->mediumPermission->getCategoryRestrictions(1, 1);
+        $this->assertCount(2, $restrictions);
+        $this->assertContains(10, $restrictions);
+        $this->assertContains(20, $restrictions);
+
+        // Cleanup
+        $this->mediumPermission->deleteGroup(1);
+    }
+
+    public function testGetAllCategoryRestrictions(): void
+    {
+        $groupData = [
+            'name' => 'TestGroup',
+            'description' => 'TestDescription',
+            'auto_join' => false,
+        ];
+        $this->mediumPermission->addGroup($groupData);
+
+        $this->mediumPermission->setCategoryRestrictions(1, 1, [10]);
+        $this->mediumPermission->setCategoryRestrictions(1, 2, [20, 30]);
+
+        $all = $this->mediumPermission->getAllCategoryRestrictions(1);
+        $this->assertCount(2, $all);
+        $this->assertArrayHasKey(1, $all);
+        $this->assertArrayHasKey(2, $all);
+
+        // Cleanup
+        $this->mediumPermission->deleteGroup(1);
+    }
+
+    public function testDeleteGroupCleansCategoryRestrictions(): void
+    {
+        $groupData = [
+            'name' => 'TestGroup',
+            'description' => 'TestDescription',
+            'auto_join' => false,
+        ];
+        $this->mediumPermission->addGroup($groupData);
+        $this->mediumPermission->setCategoryRestrictions(1, 1, [10, 20]);
+
+        $this->assertTrue($this->mediumPermission->deleteGroup(1));
+        $this->assertEmpty($this->mediumPermission->getAllCategoryRestrictions(1));
     }
 
     private function initializeDatabaseStatics(Sqlite3 $dbHandle): void

--- a/tests/phpMyFAQ/Setup/Installation/DatabaseSchemaTest.php
+++ b/tests/phpMyFAQ/Setup/Installation/DatabaseSchemaTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseSchemaTest extends TestCase
 {
-    private const EXPECTED_TABLE_COUNT = 51;
+    private const EXPECTED_TABLE_COUNT = 53;
 
     /**
      * @return array<string, array{DialectInterface}>
@@ -45,7 +45,7 @@ class DatabaseSchemaTest extends TestCase
         $this->assertContains('faqdata', $names);
         $this->assertContains('faquser', $names);
         $this->assertContains('faqconfig', $names);
-
+        $this->assertContains('faqrate_limits', $names);
         $this->assertContains('faqapi_keys', $names);
         $this->assertContains('faqoauth_clients', $names);
         $this->assertContains('faqoauth_access_tokens', $names);

--- a/tests/phpMyFAQ/Setup/Installation/DatabaseSchemaTest.php
+++ b/tests/phpMyFAQ/Setup/Installation/DatabaseSchemaTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseSchemaTest extends TestCase
 {
-    private const EXPECTED_TABLE_COUNT = 53;
+    private const EXPECTED_TABLE_COUNT = 52;
 
     /**
      * @return array<string, array{DialectInterface}>
@@ -45,7 +45,7 @@ class DatabaseSchemaTest extends TestCase
         $this->assertContains('faqdata', $names);
         $this->assertContains('faquser', $names);
         $this->assertContains('faqconfig', $names);
-        $this->assertContains('faqrate_limits', $names);
+        $this->assertContains('faqgroup_right_category', $names);
         $this->assertContains('faqapi_keys', $names);
         $this->assertContains('faqoauth_clients', $names);
         $this->assertContains('faqoauth_access_tokens', $names);

--- a/tests/phpMyFAQ/Setup/Installation/SchemaInstallerTest.php
+++ b/tests/phpMyFAQ/Setup/Installation/SchemaInstallerTest.php
@@ -50,7 +50,7 @@ class SchemaInstallerTest extends TestCase
                 $createTableCount++;
             }
         }
-        $this->assertEquals(51, $createTableCount, 'Should generate CREATE TABLE for all 51 tables');
+        $this->assertEquals(53, $createTableCount, 'Should generate CREATE TABLE for all 53 tables');
     }
 
     #[DataProvider('dialectProvider')]

--- a/tests/phpMyFAQ/Setup/Installation/SchemaInstallerTest.php
+++ b/tests/phpMyFAQ/Setup/Installation/SchemaInstallerTest.php
@@ -50,7 +50,7 @@ class SchemaInstallerTest extends TestCase
                 $createTableCount++;
             }
         }
-        $this->assertEquals(53, $createTableCount, 'Should generate CREATE TABLE for all 53 tables');
+        $this->assertEquals(52, $createTableCount, 'Should generate CREATE TABLE for all 52 tables');
     }
 
     #[DataProvider('dialectProvider')]

--- a/tests/phpMyFAQ/Setup/Migration/MigrationRegistryTest.php
+++ b/tests/phpMyFAQ/Setup/Migration/MigrationRegistryTest.php
@@ -42,6 +42,7 @@ class MigrationRegistryTest extends TestCase
         $this->assertContains('3.2.0-alpha', $versions);
         $this->assertContains('4.0.0-alpha', $versions);
         $this->assertContains('4.2.0-alpha', $versions);
+        $this->assertContains('4.2.0-alpha.2', $versions);
     }
 
     public function testGetVersionsAreSorted(): void
@@ -92,7 +93,7 @@ class MigrationRegistryTest extends TestCase
         $latestVersion = $this->registry->getLatestVersion();
 
         $this->assertNotNull($latestVersion);
-        $this->assertEquals('4.2.0-alpha', $latestVersion);
+        $this->assertEquals('4.2.0-alpha.2', $latestVersion);
     }
 
     public function testGetPendingMigrationsFromOldVersion(): void
@@ -105,7 +106,7 @@ class MigrationRegistryTest extends TestCase
 
     public function testGetPendingMigrationsFromCurrentVersion(): void
     {
-        $pending = $this->registry->getPendingMigrations('4.2.0-alpha');
+        $pending = $this->registry->getPendingMigrations('4.2.0-alpha.2');
 
         $this->assertEmpty($pending);
     }
@@ -118,6 +119,7 @@ class MigrationRegistryTest extends TestCase
         $this->assertArrayHasKey('4.0.5', $pending);
         $this->assertArrayHasKey('4.1.0-alpha', $pending);
         $this->assertArrayHasKey('4.2.0-alpha', $pending);
+        $this->assertArrayHasKey('4.2.0-alpha.2', $pending);
 
         // Should not include versions before or equal to 4.0.0
         $this->assertArrayNotHasKey('3.2.0-alpha', $pending);


### PR DESCRIPTION
Groups can now have their permissions scoped to specific categories. When no category restrictions are set, rights apply globally (backward compatible). This enables controlled external contributions where users can be restricted to specific categories via group membership.

New table faqgroup_right_category links group rights to categories. Added API endpoints for managing category restrictions, admin UI panel for configuring restrictions per permission, and hasPermissionForCategory() for category-scoped permission checks.

This feature implements and closes #3780.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can set per-category access restrictions for groups via a new UI panel with save controls.

* **API**
  * New admin endpoints to list categories and to load/save group–category restriction settings (CSRF-protected).

* **Database**
  * Migration adds storage for group–right–category mappings; group deletion now clears related entries.

* **Permission**
  * Permission checks now respect category-scoped group rights.

* **Tests**
  * Comprehensive tests added for storage, enforcement, cleanup, and migration behavior.

* **Localization**
  * English labels and help text for the category restrictions UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thorsten/phpMyFAQ/pull/4073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->