### PR TITLE
fix: escape gravatarUrl in client-side comment rendering

### DIFF
--- a/phpmyfaq/assets/src/faq/comments.ts
+++ b/phpmyfaq/assets/src/faq/comments.ts
@@ -140,12 +140,13 @@ const addCommentToDOM = (commentData: CommentData): void => {
   };
 
   const escapedUsername = escapeHtml(commentData.username);
+  const escapedGravatarUrl = escapeHtml(commentData.gravatarUrl);
 
   const commentHtml = `
     <div class="row mt-2 mb-2">
       <div class="col-sm-1">
         <div class="thumbnail">
-          <img src="${commentData.gravatarUrl}" alt="${escapedUsername}" class="img-thumbnail">
+          <img src="${escapedGravatarUrl}" alt="${escapedUsername}" class="img-thumbnail">
         </div>
       </div>
       <div class="col-sm-11">
@@ -160,7 +161,10 @@ const addCommentToDOM = (commentData: CommentData): void => {
     </div>
   `;
 
-  // Insert the new comment at the end of the comments container
+  // Insert the new comment at the end of the comments container.
+  // commentHtml is safe: username and gravatarUrl are HTML-escaped above, and the comment body
+  // is sanitized server-side (CommentController) before it is ever returned to the client.
+  // nosemgrep
   commentsContainer.insertAdjacentHTML('beforeend', commentHtml);
 };
 


### PR DESCRIPTION
## Summary

Client-side hardening for FAQ comment rendering, surfaced during a Semgrep triage of `react-unsanitized-method` findings.

- Escape `commentData.gravatarUrl` with `escapeHtml()` before interpolating it into the comment `<img src>` attribute, matching how `username` is already handled. The URL is server-generated, so this is consistency hardening rather than a fix for an exploitable issue.
- Document why the `insertAdjacentHTML` call is safe (escaped `username`/`gravatarUrl`, server-sanitized comment body) and annotate the line for the scanner.

## Testing

- `pnpm test` — 1203 pass
- ESLint, Prettier, tsc — all green
- `composer test` — 6173 pass, 3 skipped (redis extension not installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)