### PR TITLE
fix: send HTTP 503 from Database::errorPage()

### DIFF
--- a/phpmyfaq/src/phpMyFAQ/Database.php
+++ b/phpmyfaq/src/phpMyFAQ/Database.php
@@ -102,6 +102,10 @@ class Database
      */
     public static function errorPage(string $method): void
     {
+        if (!headers_sent()) {
+            http_response_code(503);
+            header('Retry-After: 60');
+        }
         echo
             '<!DOCTYPE html>
             <html lang="en" class="no-js">

--- a/phpmyfaq/src/phpMyFAQ/Database.php
+++ b/phpmyfaq/src/phpMyFAQ/Database.php
@@ -103,7 +103,7 @@ class Database
     public static function errorPage(string $method): void
     {
         if (!headers_sent()) {
-            http_response_code(503);
+            header('HTTP/1.1 503 Service Unavailable', true, 503);
             header('Retry-After: 60');
         }
         echo

--- a/tests/phpMyFAQ/DatabaseTest.php
+++ b/tests/phpMyFAQ/DatabaseTest.php
@@ -66,6 +66,8 @@ class DatabaseTest extends TestCase
         $output = ob_get_clean();
 
         $this->assertEquals(503, http_response_code());
+        $this->assertContains('Retry-After: 60', headers_list());
+        $this->assertStringContainsString('<title>Fatal phpMyFAQ Error</title>', $output);
         $this->assertStringContainsString('<title>Fatal phpMyFAQ Error</title>', $output);
         $this->assertStringContainsString(
             '<p class="alert alert-danger mt-5">The connection to the database server could not be established.</p>',

--- a/tests/phpMyFAQ/DatabaseTest.php
+++ b/tests/phpMyFAQ/DatabaseTest.php
@@ -61,7 +61,6 @@ class DatabaseTest extends TestCase
 
     public function testErrorPage(): void
     {
-        http_response_code(200);
         ob_start();
         Database::errorPage('Error message');
         $output = ob_get_clean();

--- a/tests/phpMyFAQ/DatabaseTest.php
+++ b/tests/phpMyFAQ/DatabaseTest.php
@@ -61,10 +61,12 @@ class DatabaseTest extends TestCase
 
     public function testErrorPage(): void
     {
+        http_response_code(200);
         ob_start();
         Database::errorPage('Error message');
         $output = ob_get_clean();
 
+        $this->assertEquals(503, http_response_code());
         $this->assertStringContainsString('<title>Fatal phpMyFAQ Error</title>', $output);
         $this->assertStringContainsString(
             '<p class="alert alert-danger mt-5">The connection to the database server could not be established.</p>',

--- a/tests/phpMyFAQ/DatabaseTest.php
+++ b/tests/phpMyFAQ/DatabaseTest.php
@@ -66,8 +66,9 @@ class DatabaseTest extends TestCase
         $output = ob_get_clean();
 
         $this->assertEquals(503, http_response_code());
-        $this->assertContains('Retry-After: 60', headers_list());
-        $this->assertStringContainsString('<title>Fatal phpMyFAQ Error</title>', $output);
+        if (function_exists('xdebug_get_headers')) {
+            $this->assertContains('Retry-After: 60', xdebug_get_headers());
+        }
         $this->assertStringContainsString('<title>Fatal phpMyFAQ Error</title>', $output);
         $this->assertStringContainsString(
             '<p class="alert alert-danger mt-5">The connection to the database server could not be established.</p>',


### PR DESCRIPTION
Closes #4271.

### Problem

`Database::errorPage()` echoes the "Fatal phpMyFAQ Error" body without setting an HTTP status, so the response goes out with the PHP default `200 OK`. Downstream caches treat that as a cacheable success and keep serving the error page after the DB has recovered, and status-only health checks (Nagios, uptime probes, k8s readiness) report green during the outage.

### Change

Set `http_response_code(503)` and `Retry-After: 60` before emitting the body. Guarded by `headers_sent()` so any caller that happens to have output something already is not broken with a warning.

`503 Service Unavailable` is the correct semantic for a transient backend dependency failure; `Retry-After` is the standard hint for clients and caches.

### Test

`testErrorPage()` extended: resets the status to 200 before the call and asserts that `http_response_code()` returns `503` after `errorPage()` runs. The existing string assertions on the body remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error page now sends a 503 Service Unavailable status and a Retry-After: 60 header when appropriate, improving client-side error handling and retry behavior.

* **Tests**
  * Tests updated to verify the HTTP 503 response and Retry-After header are set when the fatal error page is rendered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thorsten/phpMyFAQ/pull/4272)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->