### PR TITLE
ci(e2e): fix nightly hang on playwright install --with-deps

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -13,6 +13,16 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    # Fail fast instead of burning up to GitHub's 6h cap if a step hangs.
+    timeout-minutes: 30
+    # Suppress the interactive needrestart prompt that otherwise hangs
+    # `playwright install --with-deps` (sudo apt-get) forever on Ubuntu runners.
+    # DEBIAN_FRONTEND survives sudo via the runner's env_keep; NEEDRESTART_MODE=a
+    # auto-restarts services without prompting.
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      NEEDRESTART_MODE: a
+      NEEDRESTART_SUSPEND: 1
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The `playwright install --with-deps chromium` step hung indefinitely on Ubuntu runners: the chromium binary downloads fine, then the apt phase triggers needrestart, whose interactive prompt never gets a TTY in CI. With no job timeout, each run burned to GitHub's 6h cap.

Set DEBIAN_FRONTEND=noninteractive and NEEDRESTART_MODE=a (job-level, so they survive sudo via the runner's env_keep) to suppress the prompt, and add timeout-minutes: 30 so any future hang fails fast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced nightly automated test workflow with timeout protection and environment configuration improvements to prevent test hangs on Ubuntu runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->